### PR TITLE
Support inheritance

### DIFF
--- a/FiftyOne.IpIntelligence.Engine.OnPremise/FiftyOne.IpIntelligence.Engine.OnPremise.xml
+++ b/FiftyOne.IpIntelligence.Engine.OnPremise/FiftyOne.IpIntelligence.Engine.OnPremise.xml
@@ -735,13 +735,38 @@
             range that the IP address fall within
             </summary>
         </member>
+        <member name="P:FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements.IpiOnPremiseEngine.SwigFactory">
+            <summary>
+            Factory used to create a new <see cref="T:FiftyOne.IpIntelligence.Engine.OnPremise.Wrappers.IEngineSwigWrapper"/> when
+            <see cref="M:FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements.IpiOnPremiseEngine.RefreshData(System.String)"/> or 
+            <see cref="M:FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements.IpiOnPremiseEngine.RefreshData(System.String,System.IO.Stream)"/> is called.
+            </summary>
+            <remarks>
+            Must be set after construction and before usage.
+            </remarks>
+        </member>
+        <member name="P:FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements.IpiOnPremiseEngine.Config">
+            <summary>
+            Wrapper to pass general configuration from managed code to unmanaged 
+            code.
+            </summary>
+            <remarks>
+            Must be set after construction and before usage.
+            </remarks>
+        </member>
+        <member name="P:FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements.IpiOnPremiseEngine.PropertiesConfigSwig">
+            <summary>
+            Wrapper to pass property configuration from managed code to 
+            unmanaged code.
+            </summary>
+        </member>
         <member name="E:FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements.IpiOnPremiseEngine.RefreshCompleted">
             <summary>
             This event is fired whenever the data that this engine makes use
             of has been updated.
             </summary>
         </member>
-        <member name="M:FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements.IpiOnPremiseEngine.#ctor(Microsoft.Extensions.Logging.ILoggerFactory,FiftyOne.Pipeline.Engines.Data.IAspectEngineDataFile,FiftyOne.IpIntelligence.Engine.OnPremise.Wrappers.IConfigSwigWrapper,FiftyOne.IpIntelligence.Engine.OnPremise.Wrappers.IRequiredPropertiesConfigSwigWrapper,System.Func{FiftyOne.Pipeline.Core.FlowElements.IPipeline,FiftyOne.Pipeline.Core.FlowElements.FlowElementBase{FiftyOne.IpIntelligence.Engine.OnPremise.Data.IIpDataOnPremise,FiftyOne.Pipeline.Engines.FiftyOne.Data.IFiftyOneAspectPropertyMetaData},FiftyOne.IpIntelligence.Engine.OnPremise.Data.IIpDataOnPremise},System.String,FiftyOne.IpIntelligence.Engine.OnPremise.Wrappers.ISwigFactory)">
+        <member name="M:FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements.IpiOnPremiseEngine.#ctor(Microsoft.Extensions.Logging.ILoggerFactory,System.Func{FiftyOne.Pipeline.Core.FlowElements.IPipeline,FiftyOne.Pipeline.Core.FlowElements.FlowElementBase{FiftyOne.IpIntelligence.Engine.OnPremise.Data.IIpDataOnPremise,FiftyOne.Pipeline.Engines.FiftyOne.Data.IFiftyOneAspectPropertyMetaData},FiftyOne.IpIntelligence.Engine.OnPremise.Data.IIpDataOnPremise},System.String)">
             <summary>
             Construct a new instance of the IP intelligence engine.
             </summary>
@@ -895,7 +920,41 @@
             Data update service used to keep the engine's data up to date.
             </param>
         </member>
-        <member name="M:FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements.IpiOnPremiseEngineBuilder.SetReuseTempFile(System.Boolean)">
+        <member name="M:FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements.IpiOnPremiseEngineBuilder.CreateEngine(Microsoft.Extensions.Logging.ILoggerFactory,System.Func{FiftyOne.Pipeline.Core.FlowElements.IPipeline,FiftyOne.Pipeline.Core.FlowElements.FlowElementBase{FiftyOne.IpIntelligence.Engine.OnPremise.Data.IIpDataOnPremise,FiftyOne.Pipeline.Engines.FiftyOne.Data.IFiftyOneAspectPropertyMetaData},FiftyOne.IpIntelligence.Engine.OnPremise.Data.IIpDataOnPremise},System.String)">
+            <summary>
+            Creates a new instance of <see cref="!:DeviceDetectionHashEngine"/>.
+            </summary>
+            <param name="loggerFactory"></param>
+            <param name="deviceDataFactory"></param>
+            <param name="tempDataFilePath"></param>
+            <returns></returns>
+        </member>
+        <member name="T:FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements.IpiOnPremiseEngineBuilderBase`1">
+            <summary>
+            Builder for the <see cref="T:FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements.IpiOnPremiseEngine"/>. All options
+            for the engine should be set here.
+            </summary>
+        </member>
+        <member name="M:FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements.IpiOnPremiseEngineBuilderBase`1.#ctor(Microsoft.Extensions.Logging.ILoggerFactory)">
+            <summary>
+            Construct a new instance of the builder.
+            </summary>
+            <param name="loggerFactory">
+            Factory used to create loggers for the engine
+            </param>
+        </member>
+        <member name="M:FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements.IpiOnPremiseEngineBuilderBase`1.#ctor(Microsoft.Extensions.Logging.ILoggerFactory,FiftyOne.Pipeline.Engines.Services.IDataUpdateService)">
+            <summary>
+            Construct a new instance of the builder.
+            </summary>
+            <param name="loggerFactory">
+            Factory used to create loggers for the engine
+            </param>
+            <param name="dataUpdateService">
+            Data update service used to keep the engine's data up to date.
+            </param>
+        </member>
+        <member name="M:FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements.IpiOnPremiseEngineBuilderBase`1.SetReuseTempFile(System.Boolean)">
             <summary>
             Set whether or not an existing temp file should be used if one is
             found in the temp directory.
@@ -903,21 +962,21 @@
             <param name="reuse">True if an existing file should be used</param>
             <returns>This builder</returns>
         </member>
-        <member name="M:FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements.IpiOnPremiseEngineBuilder.SetPerformanceProfile(System.String)">
+        <member name="M:FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements.IpiOnPremiseEngineBuilderBase`1.SetPerformanceProfile(System.String)">
             <summary>
             Set the performance profile to use when constructing the data set.
             </summary>
             <param name="profileName">Name of the profile to use</param>
             <returns>This builder</returns>
         </member>
-        <member name="M:FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements.IpiOnPremiseEngineBuilder.SetPerformanceProfile(FiftyOne.Pipeline.Engines.PerformanceProfiles)">
+        <member name="M:FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements.IpiOnPremiseEngineBuilderBase`1.SetPerformanceProfile(FiftyOne.Pipeline.Engines.PerformanceProfiles)">
             <summary>
             Set the performance profile to use when constructing the data set.
             </summary>
             <param name="profile">Profile to use</param>
             <returns>This builder</returns>
         </member>
-        <member name="M:FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements.IpiOnPremiseEngineBuilder.SetConcurrency(System.UInt16)">
+        <member name="M:FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements.IpiOnPremiseEngineBuilderBase`1.SetConcurrency(System.UInt16)">
             <summary>
             Set the expected number of concurrent operations using the engine.
             This sets the concurrency of the internal caches to avoid excessive
@@ -926,7 +985,7 @@
             <param name="concurrency">Expected concurrent accesses</param>
             <returns>This builder</returns>
         </member>
-        <member name="M:FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements.IpiOnPremiseEngineBuilder.NewEngine(System.Collections.Generic.List{System.String})">
+        <member name="M:FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements.IpiOnPremiseEngineBuilderBase`1.NewEngine(System.Collections.Generic.List{System.String})">
             <summary>
             Called by the 'BuildEngine' method to handle
             creation of the engine instance.
@@ -936,12 +995,22 @@
             An <see cref="T:FiftyOne.Pipeline.Engines.FlowElements.IAspectEngine"/>.
             </returns>
         </member>
-        <member name="P:FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements.IpiOnPremiseEngineBuilder.DefaultDataDownloadType">
+        <member name="P:FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements.IpiOnPremiseEngineBuilderBase`1.DefaultDataDownloadType">
             <summary>
             Get the default value for the 'Type' parameter that is passed
             to the 51Degrees Distributor service when checking for updated
             data files.
             </summary>
+        </member>
+        <member name="M:FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements.IpiOnPremiseEngineBuilderBase`1.CreateEngine(Microsoft.Extensions.Logging.ILoggerFactory,System.Func{FiftyOne.Pipeline.Core.FlowElements.IPipeline,FiftyOne.Pipeline.Core.FlowElements.FlowElementBase{FiftyOne.IpIntelligence.Engine.OnPremise.Data.IIpDataOnPremise,FiftyOne.Pipeline.Engines.FiftyOne.Data.IFiftyOneAspectPropertyMetaData},FiftyOne.IpIntelligence.Engine.OnPremise.Data.IIpDataOnPremise},System.String)">
+            <summary>
+            Overridden in the implementing class to create a new instance of
+            TEngine with the constructor parameters provided.
+            </summary>
+            <param name="loggerFactory"></param>
+            <param name="deviceDataFactory"></param>
+            <param name="tempDataFilePath"></param>
+            <returns></returns>
         </member>
         <member name="T:FiftyOne.IpIntelligence.Engine.OnPremise.Interop.UTF8Marshaler">
             <summary>

--- a/FiftyOne.IpIntelligence.Engine.OnPremise/FlowElements/IpiOnPremiseEngineBuilderBase.cs
+++ b/FiftyOne.IpIntelligence.Engine.OnPremise/FlowElements/IpiOnPremiseEngineBuilderBase.cs
@@ -1,0 +1,296 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2025 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using FiftyOne.IpIntelligence.Engine.OnPremise.Data;
+using FiftyOne.IpIntelligence.Engine.OnPremise.Interop;
+using FiftyOne.IpIntelligence.Shared.FlowElements;
+using FiftyOne.Pipeline.Core.Data;
+using FiftyOne.Pipeline.Core.Exceptions;
+using FiftyOne.Pipeline.Core.FlowElements;
+using FiftyOne.Pipeline.Engines;
+using FiftyOne.Pipeline.Engines.FiftyOne.Data;
+using FiftyOne.Pipeline.Engines.FlowElements;
+using FiftyOne.Pipeline.Engines.Services;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FiftyOne.IpIntelligence.Engine.OnPremise.Wrappers;
+
+namespace FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements
+{
+    /// <summary>
+    /// Builder for the <see cref="IpiOnPremiseEngine"/>. All options
+    /// for the engine should be set here.
+    /// </summary>
+    public abstract class IpiOnPremiseEngineBuilderBase<TEngine>
+       : OnPremiseIpiEngineBuilderBase<IpiOnPremiseEngineBuilderBase<TEngine>, TEngine>
+        where TEngine : IpiOnPremiseEngine
+    {
+        #region Private Properties
+
+        private readonly ILoggerFactory _loggerFactory;
+
+        private IConfigSwigWrapper _config = null;
+
+        #endregion
+
+        internal ISwigFactory SwigFactory { get; set; } = new SwigFactory();
+
+        private IConfigSwigWrapper SwigConfig
+        {
+            get
+            {
+                if (_config == null)
+                {
+                    _config = SwigFactory.CreateConfig();
+                }
+                return _config;
+            }
+        }
+
+        #region Constructor
+
+        /// <summary>
+        /// Construct a new instance of the builder.
+        /// </summary>
+        /// <param name="loggerFactory">
+        /// Factory used to create loggers for the engine
+        /// </param>
+        public IpiOnPremiseEngineBuilderBase(
+            ILoggerFactory loggerFactory)
+            : this(loggerFactory, null)
+        {
+        }
+
+        /// <summary>
+        /// Construct a new instance of the builder.
+        /// </summary>
+        /// <param name="loggerFactory">
+        /// Factory used to create loggers for the engine
+        /// </param>
+        /// <param name="dataUpdateService">
+        /// Data update service used to keep the engine's data up to date.
+        /// </param>
+        public IpiOnPremiseEngineBuilderBase(
+            ILoggerFactory loggerFactory,
+            IDataUpdateService dataUpdateService)
+            : base(dataUpdateService)
+        {
+            _loggerFactory = loggerFactory;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Set whether or not an existing temp file should be used if one is
+        /// found in the temp directory.
+        /// </summary>
+        /// <param name="reuse">True if an existing file should be used</param>
+        /// <returns>This builder</returns>
+        public IpiOnPremiseEngineBuilderBase<TEngine> SetReuseTempFile(bool reuse)
+        {
+            SwigConfig.setReuseTempFile(reuse);
+            return this;
+        }
+
+        /// <summary>
+        /// Set the performance profile to use when constructing the data set.
+        /// </summary>
+        /// <param name="profileName">Name of the profile to use</param>
+        /// <returns>This builder</returns>
+        public IpiOnPremiseEngineBuilderBase<TEngine> SetPerformanceProfile(
+            string profileName)
+        {
+            PerformanceProfiles profile;
+            if (Enum.TryParse<PerformanceProfiles>(
+                profileName,
+                out profile))
+            {
+                return SetPerformanceProfile(profile);
+            }
+            else
+            {
+                var available = Enum.GetNames(typeof(PerformanceProfiles))
+                    .Select(i => "'" + i + "'");
+                throw new ArgumentException(
+                    $"'{profileName}' is not a valid performance profile. " +
+                    $"Available profiles are {string.Join(", ", available)}.");
+            }
+        }
+
+        /// <summary>
+        /// Set the performance profile to use when constructing the data set.
+        /// </summary>
+        /// <param name="profile">Profile to use</param>
+        /// <returns>This builder</returns>
+        public override IpiOnPremiseEngineBuilderBase<TEngine> SetPerformanceProfile(
+            PerformanceProfiles profile)
+        {
+            switch (profile)
+            {
+                case PerformanceProfiles.LowMemory:
+                    SwigConfig.setLowMemory();
+                    break;
+                case PerformanceProfiles.Balanced:
+                    SwigConfig.setBalanced();
+                    break;
+                case PerformanceProfiles.BalancedTemp:
+                    SwigConfig.setBalancedTemp();
+                    break;
+                case PerformanceProfiles.HighPerformance:
+                    SwigConfig.setHighPerformance();
+                    break;
+                case PerformanceProfiles.MaxPerformance:
+                    SwigConfig.setMaxPerformance();
+                    break;
+                default:
+                    throw new ArgumentException(
+                        $"The performance profile '{profile}' is not valid " +
+                        $"for a IpiOnPremiseEngine.",
+                        nameof(profile));
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Set the expected number of concurrent operations using the engine.
+        /// This sets the concurrency of the internal caches to avoid excessive
+        /// locking.
+        /// </summary>
+        /// <param name="concurrency">Expected concurrent accesses</param>
+        /// <returns>This builder</returns>
+        public override IpiOnPremiseEngineBuilderBase<TEngine> SetConcurrency(
+            ushort concurrency)
+        {
+            SwigConfig.setConcurrency(concurrency);
+            return this;
+        }
+
+        #endregion
+
+        #region Protected Overrides
+        /// <summary>
+        /// Called by the 'BuildEngine' method to handle
+        /// creation of the engine instance.
+        /// </summary>
+        /// <param name="properties"></param>
+        /// <returns>
+        /// An <see cref="IAspectEngine"/>.
+        /// </returns>
+        protected override TEngine NewEngine(
+            List<string> properties)
+        {
+            if (DataFiles.Count != 1)
+            {
+                throw new PipelineConfigurationException(
+                    "This builder requires one and only one configured file " +
+                    $"but it has {DataFileConfigs.Count}");
+            }
+            var dataFile = DataFiles.First();
+            // We remove the data file configuration from the list.
+            // This is because the on-premise engine builder base class 
+            // adds all the data file configs after engine creation.  
+            // However, the IP intelligence data files are supplied 
+            // directly to the constructor.
+            // Consequently, we remove it here to stop it from being added 
+            // again by the base class.
+            DataFiles.Remove(dataFile);
+
+            // Update the swig configuration object.
+            SwigConfig.setUseUpperPrefixHeaders(false);
+            if (dataFile.Configuration.CreateTempCopy && String.IsNullOrEmpty(TempDir) == false)
+            {
+                using (var tempDirs = new VectorStringSwig())
+                {
+                    tempDirs.Add(TempDir);
+                    SwigConfig.setTempDirectories(tempDirs);
+                }
+                SwigConfig.setUseTempFile(true);
+            }
+
+            // Create swig property configuration object.
+            IRequiredPropertiesConfigSwigWrapper propertyConfig = null;
+            using (var vProperties = new VectorStringSwig(properties))
+            {
+                propertyConfig = SwigFactory.CreateRequiredProperties(vProperties);
+            }
+
+            // Create a new instance of the required engine type.
+            var engine = CreateEngine(
+                _loggerFactory,
+                CreateAspectData,
+                TempDir);
+
+            // Then set the instances of properties that remain internal to
+            // the package.
+            engine.SwigFactory = SwigFactory;
+            engine.PropertiesConfigSwig = propertyConfig;
+            engine.Config = SwigConfig;
+
+            // This must be last as the call results in RefreshData being
+            // triggered which requires the prior three properties to be set.
+            engine.AddDataFile(dataFile);
+
+            return engine;
+        }
+
+        /// <summary>
+        /// Get the default value for the 'Type' parameter that is passed
+        /// to the 51Degrees Distributor service when checking for updated
+        /// data files.
+        /// </summary>
+        protected override string DefaultDataDownloadType => "IPIV41";
+        #endregion
+
+        #region Abstract Methods
+        /// <summary>
+        /// Overridden in the implementing class to create a new instance of
+        /// TEngine with the constructor parameters provided.
+        /// </summary>
+        /// <param name="loggerFactory"></param>
+        /// <param name="deviceDataFactory"></param>
+        /// <param name="tempDataFilePath"></param>
+        /// <returns></returns>
+        protected abstract TEngine CreateEngine(
+            ILoggerFactory loggerFactory,
+            Func<IPipeline, FlowElementBase<
+                IIpDataOnPremise,
+                IFiftyOneAspectPropertyMetaData>,
+                IIpDataOnPremise> deviceDataFactory,
+            string tempDataFilePath);
+        #endregion
+
+
+        private IIpDataOnPremise CreateAspectData(IPipeline pipeline,
+            FlowElementBase<IIpDataOnPremise, IFiftyOneAspectPropertyMetaData> engine)
+        {
+            return new IpDataOnPremise(
+                _loggerFactory.CreateLogger<IpDataOnPremise>(),
+                pipeline,
+                engine as IpiOnPremiseEngine,
+                MissingPropertyService.Instance);
+        }
+    }
+}

--- a/FiftyOne.IpIntelligence.Shared/FiftyOne.IpIntelligence.Shared.xml
+++ b/FiftyOne.IpIntelligence.Shared/FiftyOne.IpIntelligence.Shared.xml
@@ -647,6 +647,26 @@
             Thrown if the value was not of the expected type.
             </exception>
         </member>
+        <member name="T:FiftyOne.IpIntelligence.Shared.Data.RiskFactorEnum">
+            <summary>
+            Enum indicating the confidence associated with a network result.
+            </summary>
+        </member>
+        <member name="F:FiftyOne.IpIntelligence.Shared.Data.RiskFactorEnum.LowRisk">
+            <summary>
+            A standard wired or cellular IP with over 99% country accuracy and better than 60% combined accuracy within a 25 km radius globally.
+            </summary>
+        </member>
+        <member name="F:FiftyOne.IpIntelligence.Shared.Data.RiskFactorEnum.ModerateRisk">
+            <summary>
+            A hosting environment or ASN (like cloud servers, VPNs, proxies, TOR, etc.) but where we are confident the location represents over 60% accuracy at the country level.
+            </summary>
+        </member>
+        <member name="F:FiftyOne.IpIntelligence.Shared.Data.RiskFactorEnum.HighRisk">
+            <summary>
+            A hosting network where the location we have is likely valid for less than 50% of the traffic.
+            </summary>
+        </member>
         <member name="T:FiftyOne.IpIntelligence.Shared.Data.ValueMetaDataDefault">
             <summary>
             Data class that contains meta-data relating to a specific 


### PR DESCRIPTION
### Changes

- Make some properties `IpiOnPremiseEngine` internal.
- Rename `GetEngineMetaData` to `InitEngineMetaData`.
- Add `IpiOnPremiseEngineBuilderBase` with abstract `CreateEngine`.

### Why

https://github.com/51Degrees/ip-intelligence-dotnet/issues/72

### Related

https://github.com/51Degrees/device-detection-dotnet/pull/399