### PR TITLE
FIX: IPs are weighted in a list.

### DIFF
--- a/FiftyOne.IpIntelligence.Engine.OnPremise/Data/IpDataOnPremise.cs
+++ b/FiftyOne.IpIntelligence.Engine.OnPremise/Data/IpDataOnPremise.cs
@@ -286,41 +286,6 @@ namespace FiftyOne.IpIntelligence.Engine.OnPremise.Data
             return result;
         }
 
-        protected override IAspectPropertyValue<IPAddress> GetValueAsIpAddress(string propertyName)
-        {
-            var result = new AspectPropertyValue<IPAddress>();
-            var results = GetResultsContainingProperty(propertyName);
-
-            if (results != null)
-            {
-                using (var value = results.getValueAsIpAddress(propertyName))
-                {
-                    if (value.hasValue())
-                    {
-                        using (var addressSwig = value.getValue())
-                        {
-                            if (addressSwig.getType() != IpTypeSwig.FIFTYONE_DEGREES_IP_TYPE_INVALID) 
-                            {
-                                byte[] address = new byte[Constants.IPV6_LENGTH];
-                                addressSwig.getCopyOfIpAddress(address, (uint)address.Length);
-                                if (addressSwig.getType() == IpTypeSwig.FIFTYONE_DEGREES_IP_TYPE_IPV4)
-                                {
-                                    // Downsize the array if it is ipv4
-                                    Array.Resize(ref address, Constants.IPV4_LENGTH);
-                                }
-                                result.Value = new IPAddress(address);
-                            }
-                        }
-                    }
-                    else
-                    {
-                        result.NoValueMessage = value.getNoValueMessage();
-                    }
-                }
-            }
-            return result;
-        }
-
         #endregion
     }
 }

--- a/FiftyOne.IpIntelligence.Shared/Data/IpDataBaseOnPremise.cs
+++ b/FiftyOne.IpIntelligence.Shared/Data/IpDataBaseOnPremise.cs
@@ -339,18 +339,6 @@ namespace FiftyOne.IpIntelligence.Shared.Data
         protected abstract IAspectPropertyValue<IReadOnlyList<IWeightedValue<string>>> GetValuesAsWeightedWKTStringList(
             string propertyName, byte decimalPlaces);
 
-        /// <summary>
-        /// Get the IP address value this instance has for the specified proprety
-        /// </summary>
-        /// <param name="propertyName">
-        /// The name of the property to get value for.
-        /// </param>
-        /// <returns>
-        /// A <see cref="IPAddress"/> wrapped in a
-        /// <see cref="IAspectPropertyValue"/> instance.
-        /// </returns>
-        protected abstract IAspectPropertyValue<IPAddress> GetValueAsIpAddress(string propertyName);
-
         #endregion
 
         #region Overrides
@@ -545,11 +533,8 @@ namespace FiftyOne.IpIntelligence.Shared.Data
                         {
                             obj = GetValuesAsWeightedBoolList(key);
                         }
-                        else if (innerType == typeof(IPAddress))
-                        {
-                            obj = GetValueAsIpAddress(key);
-                        }
-                        else if (innerType == typeof(IReadOnlyList<IWeightedValue<IPAddress>>))
+                        else if (innerType == typeof(IPAddress) || 
+                            innerType == typeof(IReadOnlyList<IWeightedValue<IPAddress>>))
                         {
                             obj = GetValuesAsWeightedIPList(key);
                         }

--- a/FiftyOne.IpIntelligence.Shared/FiftyOne.IpIntelligence.Shared.xml
+++ b/FiftyOne.IpIntelligence.Shared/FiftyOne.IpIntelligence.Shared.xml
@@ -591,18 +591,6 @@
             <see cref="T:FiftyOne.Pipeline.Engines.Data.IAspectPropertyValue"/> instance.
             </returns>
         </member>
-        <member name="M:FiftyOne.IpIntelligence.Shared.Data.IpDataBaseOnPremise`1.GetValueAsIpAddress(System.String)">
-            <summary>
-            Get the IP address value this instance has for the specified proprety
-            </summary>
-            <param name="propertyName">
-            The name of the property to get value for.
-            </param>
-            <returns>
-            A <see cref="T:System.Net.IPAddress"/> wrapped in a
-            <see cref="T:FiftyOne.Pipeline.Engines.Data.IAspectPropertyValue"/> instance.
-            </returns>
-        </member>
         <member name="M:FiftyOne.IpIntelligence.Shared.Data.IpDataBaseOnPremise`1.AsDictionary">
             <summary>
             By default, the base dictionary will not be populated as 

--- a/Tests/FiftyOne.IpIntelligence.OnPremise.Tests/Data/IpDataTests.cs
+++ b/Tests/FiftyOne.IpIntelligence.OnPremise.Tests/Data/IpDataTests.cs
@@ -169,20 +169,6 @@ namespace FiftyOne.IpIntelligence.Tests.Core.Data
                 }
             }
 
-            protected override IAspectPropertyValue<IPAddress>
-                GetValueAsIpAddress(string propertyName)
-            {
-                if (propertyName == _testPropertyName)
-                {
-                    return new AspectPropertyValue<IPAddress>(
-                        (IPAddress)_value);
-                }
-                else
-                {
-                    throw new PropertyMissingException();
-                }
-            }
-
             public override IAspectPropertyValue<IReadOnlyList<string>> 
                 GetValues(string propertyName)
             {
@@ -350,9 +336,12 @@ namespace FiftyOne.IpIntelligence.Tests.Core.Data
         public void GetIpAddress()
         {
             SetupElementProperties(typeof(IPAddress));
-            IPAddress expected = IPAddress.Parse("::1");
-            TestResults<IPAddress> results =
-                new TestResults<IPAddress>(
+            IReadOnlyList<IWeightedValue<IPAddress>> expected = new List<WeightedValue<IPAddress>>()
+            {
+                new WeightedValue<IPAddress>(ushort.MaxValue, IPAddress.Parse("::1")),
+            };
+            TestResults<IReadOnlyList<IWeightedValue<IPAddress>>> results =
+                new TestResults<IReadOnlyList<IWeightedValue<IPAddress>>>(
                     _logger.Object,
                     _flowData.Object.Pipeline,
                     _engine.Object,


### PR DESCRIPTION
### Changes

- Align extraction for dictionary to normal one.

### Why

<img width="2560" height="1380" alt="Screenshot 2025-08-08 170633" src="https://github.com/user-attachments/assets/742853f6-dd00-4cad-88a2-b560aec9f027" />
<img width="2560" height="1380" alt="Screenshot 2025-08-08 172025" src="https://github.com/user-attachments/assets/d1439c62-5b4b-498d-99ad-8774d8c0bcc5" />
