### PR TITLE
Fix `IPAddress` handling in `Values_OnPremise_Core_ValueTypes`.

### DIFF
--- a/Tests/FiftyOne.IpIntelligence.TestHelpers/Data/ValueTests.cs
+++ b/Tests/FiftyOne.IpIntelligence.TestHelpers/Data/ValueTests.cs
@@ -27,6 +27,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Reflection;
 using System.Text;
 using System.Threading;
@@ -69,9 +70,9 @@ namespace FiftyOne.IpIntelligence.TestHelpers.Data
                 {
                     expectedType = typeof(IReadOnlyList<IWeightedValue<bool>>);
                 }
-                else if (property.Type == typeof(float))
+                else if (property.Type == typeof(IPAddress))
                 {
-                    expectedType = typeof(IReadOnlyList<IWeightedValue<float>>);
+                    expectedType = typeof(IReadOnlyList<IWeightedValue<IPAddress>>);
                 }
 
                 var value = elementData[property.Name];


### PR DESCRIPTION
### Changes

- Fix double `float` branches and missing `IPAddress` one in `Values_OnPremise_Core_ValueTypes`.

### Why

- 🔺 https://github.com/51Degrees/ip-intelligence-dotnet/runs/48052295901