### PR TITLE
Add `dotnet restore` invocation after `dotnet list` failures.

### DIFF
--- a/ci/run-integration-tests.ps1
+++ b/ci/run-integration-tests.ps1
@@ -76,7 +76,16 @@ try {
             Write-Warning "--- RAW OUTPUT START ---"
             Write-Warning ($PackagesRaw -Join "`n")
             Write-Warning "--- RAW OUTPUT END ---"
-            Write-Error "LASTEXITCODE = $LASTEXITCODE"
+            Write-Warning "^ LASTEXITCODE (dotnet list) = $LASTEXITCODE"
+            $LASTEXITCODE_DOTNET_LIST = $LASTEXITCODE
+            try {
+                $ErrorActionPreference = "Continue"
+                dotnet restore
+                Write-Warning "LASTEXITCODE (dotnet restore) = $LASTEXITCODE"
+            } finally {
+                $ErrorActionPreference = "Stop"
+            }
+            Write-Error "LASTEXITCODE (dotnet list) = $LASTEXITCODE_DOTNET_LIST"
         }
         $PackagesNow = ($PackagesRaw | ConvertFrom-Json)
         $ToRemove = $PackagesNow.Projects | ForEach-Object {


### PR DESCRIPTION
### Changes

- Add `dotnet restore` invocation after `dotnet list` failures.

### Why

- https://github.com/51Degrees/ip-intelligence-dotnet/actions/runs/19425481343/job/55573737352#step:6:614
```
  WARNING: --- RAW OUTPUT START ---
  WARNING: {
     "version": 1,
     "problems": [
        {
           "text": "Restore failed. Run `dotnet restore` for more details on the issue.",
           "level": "error"
        }
     ]
  }
  WARNING: --- RAW OUTPUT END ---
```