### PR TITLE
countries translation engines: align engine and builder inheritence

### DIFF
--- a/FiftyOne.IpIntelligence.Translation/FiftyOne.IpIntelligence.Translation.xml
+++ b/FiftyOne.IpIntelligence.Translation/FiftyOne.IpIntelligence.Translation.xml
@@ -221,6 +221,13 @@
             </summary>
             <returns></returns>
         </member>
+        <member name="M:FiftyOne.IpIntelligence.Translation.FlowElements.CountriesTranslationEngineBuilder.CreateEngine(Microsoft.Extensions.Logging.ILogger{FiftyOne.Pipeline.Core.FlowElements.FlowElementBase{FiftyOne.IpIntelligence.Translation.Data.ICountriesTranslationData,FiftyOne.Pipeline.Core.Data.IElementPropertyMetaData}},System.Collections.Generic.IReadOnlyList{System.Collections.Generic.KeyValuePair{System.String,System.String}},System.Func{FiftyOne.Pipeline.Core.FlowElements.IPipeline,FiftyOne.Pipeline.Core.FlowElements.FlowElementBase{FiftyOne.IpIntelligence.Translation.Data.ICountriesTranslationData,FiftyOne.Pipeline.Core.Data.IElementPropertyMetaData},FiftyOne.IpIntelligence.Translation.Data.ICountriesTranslationData})">
+            <summary>
+            Construct the engine instance. Subclasses can override this to
+            return a derived engine type while reusing the rest of
+            <see cref="M:FiftyOne.IpIntelligence.Translation.FlowElements.CountriesTranslationEngineBuilder.Build"/>.
+            </summary>
+        </member>
         <member name="T:FiftyOne.IpIntelligence.Translation.FlowElements.CountryCodeTranslationEngine">
             <summary>
             Engine which takes the country code properties from IP Intelligence
@@ -268,6 +275,13 @@
             Build a new instance of <see cref="T:FiftyOne.IpIntelligence.Translation.FlowElements.CountryCodeTranslationEngine"/>.
             </summary>
             <returns></returns>
+        </member>
+        <member name="M:FiftyOne.IpIntelligence.Translation.FlowElements.CountryCodeTranslationEngineBuilder.CreateEngine(Microsoft.Extensions.Logging.ILogger{FiftyOne.Pipeline.Core.FlowElements.FlowElementBase{FiftyOne.IpIntelligence.Translation.Data.ICountryCodeTranslationData,FiftyOne.Pipeline.Core.Data.IElementPropertyMetaData}},System.Func{FiftyOne.Pipeline.Core.FlowElements.IPipeline,FiftyOne.Pipeline.Core.FlowElements.FlowElementBase{FiftyOne.IpIntelligence.Translation.Data.ICountryCodeTranslationData,FiftyOne.Pipeline.Core.Data.IElementPropertyMetaData},FiftyOne.IpIntelligence.Translation.Data.ICountryCodeTranslationData})">
+            <summary>
+            Construct the engine instance. Subclasses can override this to
+            return a derived engine type while reusing the rest of
+            <see cref="M:FiftyOne.IpIntelligence.Translation.FlowElements.CountryCodeTranslationEngineBuilder.Build"/>.
+            </summary>
         </member>
         <member name="M:FiftyOne.IpIntelligence.Translation.FlowElements.CountryCodeTranslationEngineBuilder.CreateData(FiftyOne.Pipeline.Core.FlowElements.IPipeline,FiftyOne.Pipeline.Core.FlowElements.FlowElementBase{FiftyOne.IpIntelligence.Translation.Data.ICountryCodeTranslationData,FiftyOne.Pipeline.Core.Data.IElementPropertyMetaData})">
             <summary>

--- a/FiftyOne.IpIntelligence.Translation/FiftyOne.IpIntelligence.Translation.xml
+++ b/FiftyOne.IpIntelligence.Translation/FiftyOne.IpIntelligence.Translation.xml
@@ -176,6 +176,15 @@
         <member name="P:FiftyOne.IpIntelligence.Translation.FlowElements.CountriesTranslationEngine.ElementDataKey">
             <inheritdoc/>
         </member>
+        <member name="P:FiftyOne.IpIntelligence.Translation.FlowElements.CountriesTranslationEngine.Properties">
+            <summary>
+            Reflects over <see cref="T:FiftyOne.IpIntelligence.Translation.Data.ICountriesTranslationData"/> so each
+            property is advertised with the unwrapped <see cref="T:FiftyOne.Pipeline.Engines.Data.IAspectPropertyValue`1"/>
+            type instead of the <see cref="T:FiftyOne.Pipeline.Translation.FlowElements.TranslationEngineBase`1"/> default of
+            <c>typeof(object)</c>. Covers both the weighted translations the base
+            class produces and the "All" / Codes-All lists computed here.
+            </summary>
+        </member>
         <member name="M:FiftyOne.IpIntelligence.Translation.FlowElements.CountriesTranslationEngine.#ctor(Microsoft.Extensions.Logging.ILogger{FiftyOne.Pipeline.Core.FlowElements.FlowElementBase{FiftyOne.IpIntelligence.Translation.Data.ICountriesTranslationData,FiftyOne.Pipeline.Core.Data.IElementPropertyMetaData}},System.Collections.Generic.IReadOnlyList{System.Collections.Generic.KeyValuePair{System.String,System.String}},System.Func{FiftyOne.Pipeline.Core.FlowElements.IPipeline,FiftyOne.Pipeline.Core.FlowElements.FlowElementBase{FiftyOne.IpIntelligence.Translation.Data.ICountriesTranslationData,FiftyOne.Pipeline.Core.Data.IElementPropertyMetaData},FiftyOne.IpIntelligence.Translation.Data.ICountriesTranslationData})">
             <summary>
             Constructor. Accessible to the package builder and to subclasses

--- a/FiftyOne.IpIntelligence.Translation/FlowElements/CountriesTranslationEngine.cs
+++ b/FiftyOne.IpIntelligence.Translation/FlowElements/CountriesTranslationEngine.cs
@@ -83,9 +83,41 @@ namespace FiftyOne.IpIntelligence.Translation.FlowElements
         private readonly IReadOnlyList<CountryCodeNamePair>
             _allCountries;
 
+        private IList<IElementPropertyMetaData> _properties;
+
         /// <inheritdoc/>
         public override string ElementDataKey =>
             Constants.CountryNamesTranslatedKey;
+
+        /// <summary>
+        /// Reflects over <see cref="ICountriesTranslationData"/> so each
+        /// property is advertised with the unwrapped <see cref="IAspectPropertyValue{T}"/>
+        /// type instead of the <see cref="TranslationEngineBase{T}"/> default of
+        /// <c>typeof(object)</c>. Covers both the weighted translations the base
+        /// class produces and the "All" / Codes-All lists computed here.
+        /// </summary>
+        public override IList<IElementPropertyMetaData> Properties
+        {
+            get
+            {
+                if (_properties == null)
+                {
+                    _properties = typeof(ICountriesTranslationData)
+                        .GetProperties()
+                        .Where(p => p.PropertyType.IsGenericType
+                            && p.PropertyType.GetGenericTypeDefinition()
+                                == typeof(IAspectPropertyValue<>))
+                        .Select(p =>
+                            (IElementPropertyMetaData)new ElementPropertyMetaData(
+                                this,
+                                p.Name,
+                                p.PropertyType.GetGenericArguments()[0],
+                                available: true))
+                        .ToList();
+                }
+                return _properties;
+            }
+        }
 
         /// <summary>
         /// Constructor. Accessible to the package builder and to subclasses

--- a/FiftyOne.IpIntelligence.Translation/FlowElements/CountriesTranslationEngineBuilder.cs
+++ b/FiftyOne.IpIntelligence.Translation/FlowElements/CountriesTranslationEngineBuilder.cs
@@ -26,6 +26,7 @@ using FiftyOne.Pipeline.Core.Data;
 using FiftyOne.Pipeline.Core.FlowElements;
 using FiftyOne.Pipeline.Translation.Data;
 using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using YamlDotNet.Serialization;
@@ -49,7 +50,7 @@ namespace FiftyOne.IpIntelligence.Translation.FlowElements
         /// <param name="loggerFactory">
         /// Logger factory used by the engine and any element data created.
         /// </param>
-        public CountriesTranslationEngineBuilder(ILoggerFactory loggerFactory) 
+        public CountriesTranslationEngineBuilder(ILoggerFactory loggerFactory)
         {
             _loggerFactory = loggerFactory;
         }
@@ -69,13 +70,36 @@ namespace FiftyOne.IpIntelligence.Translation.FlowElements
             var allCountries = dict?.ToList()
                 ?? new List<KeyValuePair<string, string>>();
 
-            return new CountriesTranslationEngine(
+            return CreateEngine(
                 _loggerFactory.CreateLogger<CountriesTranslationEngine>(),
                 allCountries,
                 CreateData);
         }
 
-        private static IDictionary<string, string> DeserializeYaml(string inputYaml) 
+        /// <summary>
+        /// Construct the engine instance. Subclasses can override this to
+        /// return a derived engine type while reusing the rest of
+        /// <see cref="Build"/>.
+        /// </summary>
+        protected virtual CountriesTranslationEngine CreateEngine(
+            ILogger<FlowElementBase<
+                ICountriesTranslationData,
+                IElementPropertyMetaData>> logger,
+            IReadOnlyList<KeyValuePair<string, string>> allCountries,
+            Func<
+                IPipeline,
+                FlowElementBase<
+                    ICountriesTranslationData,
+                    IElementPropertyMetaData>,
+                ICountriesTranslationData> elementDataFactory)
+        {
+            return new CountriesTranslationEngine(
+                logger,
+                allCountries,
+                elementDataFactory);
+        }
+
+        private static IDictionary<string, string> DeserializeYaml(string inputYaml)
             => new DeserializerBuilder()
             .IgnoreUnmatchedProperties()
             .Build()

--- a/FiftyOne.IpIntelligence.Translation/FlowElements/CountryCodeTranslationEngineBuilder.cs
+++ b/FiftyOne.IpIntelligence.Translation/FlowElements/CountryCodeTranslationEngineBuilder.cs
@@ -24,6 +24,7 @@ using FiftyOne.IpIntelligence.Translation.Data;
 using FiftyOne.Pipeline.Core.Data;
 using FiftyOne.Pipeline.Core.FlowElements;
 using Microsoft.Extensions.Logging;
+using System;
 
 namespace FiftyOne.IpIntelligence.Translation.FlowElements
 {
@@ -53,9 +54,30 @@ namespace FiftyOne.IpIntelligence.Translation.FlowElements
         /// <returns></returns>
         public CountryCodeTranslationEngine Build()
         {
-            return new CountryCodeTranslationEngine(
+            return CreateEngine(
                 _loggerFactory.CreateLogger<CountryCodeTranslationEngine>(),
                 CreateData);
+        }
+
+        /// <summary>
+        /// Construct the engine instance. Subclasses can override this to
+        /// return a derived engine type while reusing the rest of
+        /// <see cref="Build"/>.
+        /// </summary>
+        protected virtual CountryCodeTranslationEngine CreateEngine(
+            ILogger<FlowElementBase<
+                ICountryCodeTranslationData,
+                IElementPropertyMetaData>> logger,
+            Func<
+                IPipeline,
+                FlowElementBase<
+                    ICountryCodeTranslationData,
+                    IElementPropertyMetaData>,
+                ICountryCodeTranslationData> elementDataFactory)
+        {
+            return new CountryCodeTranslationEngine(
+                logger,
+                elementDataFactory);
         }
 
         /// <summary>


### PR DESCRIPTION
**Why?** 

So that cloud could simply inherit both builder and engine and return an inherited engine type from inherited builder type

**Also** 

Exposed property type metadata (handy for accessibleproperties)