### PR TITLE
FIX: Exclude IP/IPv6 entries from AsDictionary when not present in evidence

### DIFF
--- a/FiftyOne.IpIntelligence.Engine.OnPremise/Data/IpDataOnPremise.cs
+++ b/FiftyOne.IpIntelligence.Engine.OnPremise/Data/IpDataOnPremise.cs
@@ -69,6 +69,7 @@ namespace FiftyOne.IpIntelligence.Engine.OnPremise.Data
             IMissingPropertyService missingPropertyService)
             : base(logger, pipeline, engine, missingPropertyService)
         {
+            _asDict = new Lazy<IReadOnlyDictionary<string, object>>(AsStrippedDictionary);
         }
 
         #endregion
@@ -79,6 +80,8 @@ namespace FiftyOne.IpIntelligence.Engine.OnPremise.Data
             new FiftyOne.Pipeline.Engines.Data.AspectPropertyValue<System.Net.IPAddress>();
         private FiftyOne.Pipeline.Engines.Data.AspectPropertyValue<System.Net.IPAddress> _echoIpV6 =
             new FiftyOne.Pipeline.Engines.Data.AspectPropertyValue<System.Net.IPAddress>();
+
+        private readonly Lazy<IReadOnlyDictionary<string, object>> _asDict;
 
         /// <summary>
         /// Set the echo IP values captured from request evidence.
@@ -120,25 +123,26 @@ namespace FiftyOne.IpIntelligence.Engine.OnPremise.Data
         /// evidence. Direct .NET accessors are unchanged.
         /// </summary>
         public override IReadOnlyDictionary<string, object> AsDictionary()
-        {
-            var dict = base.AsDictionary();
-            if (_echoIp.HasValue && _echoIpV6.HasValue)
-            {
-                return dict;
-            }
+            => _asDict.Value;
 
-            var filtered = dict.ToDictionary(
-                kv => kv.Key, kv => kv.Value,
-                StringComparer.InvariantCultureIgnoreCase);
-            if (_echoIp.HasValue == false)
-            {
-                filtered.Remove("ip");
-            }
-            if (_echoIpV6.HasValue == false)
-            {
-                filtered.Remove("ipv6");
-            }
-            return filtered;
+        private IReadOnlyDictionary<string, object> AsStrippedDictionary()
+        {
+            return base.AsDictionary()
+                .Where(x =>
+                {
+                    if (string.Compare(x.Key, "ip", StringComparison.InvariantCultureIgnoreCase) == 0)
+                    {
+                        return _echoIp.HasValue;
+                    }
+                    if (string.Compare(x.Key, "ipv6", StringComparison.InvariantCultureIgnoreCase) == 0)
+                    {
+                        return _echoIpV6.HasValue;
+                    }
+                    return true;
+                }).ToDictionary(
+                    kv => kv.Key, kv => kv.Value,
+                    StringComparer.InvariantCultureIgnoreCase);
+            
         }
         #endregion
 

--- a/FiftyOne.IpIntelligence.Engine.OnPremise/Data/IpDataOnPremise.cs
+++ b/FiftyOne.IpIntelligence.Engine.OnPremise/Data/IpDataOnPremise.cs
@@ -114,6 +114,32 @@ namespace FiftyOne.IpIntelligence.Engine.OnPremise.Data
         {
             Results.AddResult(results);
         }
+
+        /// <summary>
+        /// Drops the Ip and IpV6 entries when the matching address is not in
+        /// evidence. Direct .NET accessors are unchanged.
+        /// </summary>
+        public override IReadOnlyDictionary<string, object> AsDictionary()
+        {
+            var dict = base.AsDictionary();
+            if (_echoIp.HasValue && _echoIpV6.HasValue)
+            {
+                return dict;
+            }
+
+            var filtered = dict.ToDictionary(
+                kv => kv.Key, kv => kv.Value,
+                StringComparer.InvariantCultureIgnoreCase);
+            if (_echoIp.HasValue == false)
+            {
+                filtered.Remove("ip");
+            }
+            if (_echoIpV6.HasValue == false)
+            {
+                filtered.Remove("ipv6");
+            }
+            return filtered;
+        }
         #endregion
 
         #region Private Methods

--- a/FiftyOne.IpIntelligence.Engine.OnPremise/FiftyOne.IpIntelligence.Engine.OnPremise.xml
+++ b/FiftyOne.IpIntelligence.Engine.OnPremise/FiftyOne.IpIntelligence.Engine.OnPremise.xml
@@ -244,6 +244,12 @@
             <param name="ipv4">Parsed IPv4 address, or null if none.</param>
             <param name="ipv6">Parsed IPv6 address, or null if none.</param>
         </member>
+        <member name="M:FiftyOne.IpIntelligence.Engine.OnPremise.Data.IpDataOnPremise.AsDictionary">
+            <summary>
+            Drops the Ip and IpV6 entries when the matching address is not in
+            evidence. Direct .NET accessors are unchanged.
+            </summary>
+        </member>
         <member name="T:FiftyOne.IpIntelligence.Engine.OnPremise.Data.ProfileMetaData">
             <summary>
             Data class that contains meta-data relating to a specific 

--- a/FiftyOne.IpIntelligence.Shared/FiftyOne.IpIntelligence.Shared.xml
+++ b/FiftyOne.IpIntelligence.Shared/FiftyOne.IpIntelligence.Shared.xml
@@ -1098,12 +1098,7 @@
         </member>
         <member name="P:FiftyOne.IpIntelligence.Shared.IpIntelligenceData.Ip">
             <summary>
-            The IPv4 address of the request as a string.
-            </summary>
-        </member>
-        <member name="P:FiftyOne.IpIntelligence.Shared.IpIntelligenceData.IpV6">
-            <summary>
-            The IPv6 address of the request as a string.
+            The IPv4 address of the request.
             </summary>
         </member>
         <member name="P:FiftyOne.IpIntelligence.Shared.IpIntelligenceData.IpRangeEnd">
@@ -1114,6 +1109,11 @@
         <member name="P:FiftyOne.IpIntelligence.Shared.IpIntelligenceData.IpRangeStart">
             <summary>
             Start of the IP range to which the evidence IP belongs.
+            </summary>
+        </member>
+        <member name="P:FiftyOne.IpIntelligence.Shared.IpIntelligenceData.IpV6">
+            <summary>
+            The IPv6 address of the request.
             </summary>
         </member>
         <member name="P:FiftyOne.IpIntelligence.Shared.IpIntelligenceData.IsBroadband">
@@ -1453,12 +1453,7 @@
         </member>
         <member name="P:FiftyOne.IpIntelligence.IIpIntelligenceData.Ip">
             <summary>
-            The IPv4 address of the request as a string.
-            </summary>
-        </member>
-        <member name="P:FiftyOne.IpIntelligence.IIpIntelligenceData.IpV6">
-            <summary>
-            The IPv6 address of the request as a string.
+            The IPv4 address of the request.
             </summary>
         </member>
         <member name="P:FiftyOne.IpIntelligence.IIpIntelligenceData.IpRangeEnd">
@@ -1469,6 +1464,11 @@
         <member name="P:FiftyOne.IpIntelligence.IIpIntelligenceData.IpRangeStart">
             <summary>
             Start of the IP range to which the evidence IP belongs.
+            </summary>
+        </member>
+        <member name="P:FiftyOne.IpIntelligence.IIpIntelligenceData.IpV6">
+            <summary>
+            The IPv6 address of the request.
             </summary>
         </member>
         <member name="P:FiftyOne.IpIntelligence.IIpIntelligenceData.IsBroadband">

--- a/Tests/FiftyOne.IpIntelligence.OnPremise.Tests/FlowElements/IpEchoOnPremiseCoreTests.cs
+++ b/Tests/FiftyOne.IpIntelligence.OnPremise.Tests/FlowElements/IpEchoOnPremiseCoreTests.cs
@@ -84,6 +84,12 @@ namespace FiftyOne.IpIntelligence.OnPremise.Tests.FlowElements
                 Assert.IsTrue(data.Ip.HasValue, "Ip should have a value for IPv4 evidence.");
                 Assert.AreEqual(IPAddress.Parse("1.2.3.4"), data.Ip.Value);
                 Assert.IsFalse(data.IpV6.HasValue, "IpV6 should have no value for IPv4 evidence.");
+
+                var dict = data.AsDictionary();
+                Assert.IsTrue(dict.ContainsKey("ip"),
+                    "AsDictionary must contain 'ip' when IPv4 evidence is supplied.");
+                Assert.IsFalse(dict.ContainsKey("ipv6"),
+                    "AsDictionary must NOT contain 'ipv6' when only IPv4 evidence is supplied.");
             }
         }
 
@@ -99,6 +105,12 @@ namespace FiftyOne.IpIntelligence.OnPremise.Tests.FlowElements
                 Assert.IsTrue(data.IpV6.HasValue, "IpV6 should have a value for IPv6 evidence.");
                 Assert.AreEqual(IPAddress.Parse("2001:db8::1"), data.IpV6.Value);
                 Assert.IsFalse(data.Ip.HasValue, "Ip should have no value for IPv6 evidence.");
+
+                var dict = data.AsDictionary();
+                Assert.IsFalse(dict.ContainsKey("ip"),
+                    "AsDictionary must NOT contain 'ip' when only IPv6 evidence is supplied.");
+                Assert.IsTrue(dict.ContainsKey("ipv6"),
+                    "AsDictionary must contain 'ipv6' when IPv6 evidence is supplied.");
             }
         }
 
@@ -115,6 +127,12 @@ namespace FiftyOne.IpIntelligence.OnPremise.Tests.FlowElements
                 Assert.IsFalse(data.IpV6.HasValue, "IpV6 should be NoValue when no IP evidence is present.");
                 Assert.IsFalse(string.IsNullOrEmpty(data.Ip.NoValueMessage),
                     "NoValueMessage should be populated when no IP evidence is supplied.");
+
+                var dict = data.AsDictionary();
+                Assert.IsFalse(dict.ContainsKey("ip"),
+                    "AsDictionary must NOT contain 'ip' when no IP evidence is supplied.");
+                Assert.IsFalse(dict.ContainsKey("ipv6"),
+                    "AsDictionary must NOT contain 'ipv6' when no IP evidence is supplied.");
             }
         }
     }


### PR DESCRIPTION
### **Why:**

- https://github.com/51Degrees/cloud/issues/113

**Changes:**

`AsDictionary()` no longer emits `ip`/`ipv6` when the address isn't in evidence — before, the key stayed with a NoValue reason; the .NET accessors (`Ip`, `IpV6`) are unchanged, so only dictionary output changes. Adds tests for IPv4-only, IPv6-only and no-evidence cases.