### PR TITLE
Exclude Unknown sentinel from country All lists

### DIFF
--- a/FiftyOne.IpIntelligence.Translation/FiftyOne.IpIntelligence.Translation.xml
+++ b/FiftyOne.IpIntelligence.Translation/FiftyOne.IpIntelligence.Translation.xml
@@ -173,6 +173,14 @@
             appear in countrycodes.en_GB.yml.
             </summary>
         </member>
+        <member name="F:FiftyOne.IpIntelligence.Translation.FlowElements.CountriesTranslationEngine._validCodes">
+            <summary>
+            The set of real country codes (keys of <see cref="F:FiftyOne.IpIntelligence.Translation.FlowElements.CountriesTranslationEngine._allCountries"/>),
+            used to drop the IP engine's no-match sentinel (e.g. "Unknown") from
+            the "All" lists. Computed once since <see cref="F:FiftyOne.IpIntelligence.Translation.FlowElements.CountriesTranslationEngine._allCountries"/> is
+            immutable.
+            </summary>
+        </member>
         <member name="P:FiftyOne.IpIntelligence.Translation.FlowElements.CountriesTranslationEngine.ElementDataKey">
             <inheritdoc/>
         </member>

--- a/FiftyOne.IpIntelligence.Translation/FlowElements/CountriesTranslationEngine.cs
+++ b/FiftyOne.IpIntelligence.Translation/FlowElements/CountriesTranslationEngine.cs
@@ -83,6 +83,14 @@ namespace FiftyOne.IpIntelligence.Translation.FlowElements
         private readonly IReadOnlyList<CountryCodeNamePair>
             _allCountries;
 
+        /// <summary>
+        /// The set of real country codes (keys of <see cref="_allCountries"/>),
+        /// used to drop the IP engine's no-match sentinel (e.g. "Unknown") from
+        /// the "All" lists. Computed once since <see cref="_allCountries"/> is
+        /// immutable.
+        /// </summary>
+        private readonly HashSet<string> _validCodes;
+
         private IList<IElementPropertyMetaData> _properties;
 
         /// <inheritdoc/>
@@ -145,6 +153,9 @@ namespace FiftyOne.IpIntelligence.Translation.FlowElements
         {
             _allCountries = allCountries
                 ?? throw new ArgumentNullException(nameof(allCountries));
+            _validCodes = new HashSet<string>(
+                _allCountries.Select(c => c.Key),
+                StringComparer.OrdinalIgnoreCase);
         }
 
         /// <inheritdoc/>
@@ -226,10 +237,16 @@ namespace FiftyOne.IpIntelligence.Translation.FlowElements
             string namesPropertyName,
             string codesPropertyName)
         {
+            // The IP engine emits a sentinel code (e.g. "Unknown") when the
+            // lookup yields no real country. Keep only codes that are real
+            // countries so the sentinel never leads the list and is never
+            // re-added by the remainingPairs step below.
             var weightedTuples = BuildWeightedTuples(
-                translatedWeightedNames,
-                weightedCodes,
-                comparer).ToList();
+                    translatedWeightedNames,
+                    weightedCodes,
+                    comparer)
+                .Where(t => _validCodes.Contains(t.Key))
+                .ToList();
 
             var errors = new List<Exception>();
             var remainingPairs = _allCountries

--- a/Tests/FiftyOne.IpIntelligence.Translation.Tests/TranslationTests.cs
+++ b/Tests/FiftyOne.IpIntelligence.Translation.Tests/TranslationTests.cs
@@ -394,6 +394,125 @@ namespace FiftyOne.IpIntelligence.Translation.Tests
         }
 
         /// <summary>
+        /// When the IP lookup yields no real country (e.g. localhost / private
+        /// IP), the engine receives a sentinel "Unknown" code. "Unknown" must
+        /// never appear in any "All" list; with no real codes the lists should
+        /// be exactly all known countries ordered alphabetically, with codes
+        /// and names index-aligned.
+        /// </summary>
+        [TestMethod]
+        public void AllListsExcludeUnknownWhenNoRealCodes()
+        {
+            var ipElement = MockIpElement(
+                new[] { "Unknown" },
+                new[] { "Unknown" });
+            var codeTranslationElement =
+                new CountryCodeTranslationEngineBuilder(_loggerFactory)
+                .Build();
+            var nameTranslationElement =
+                new CountriesTranslationEngineBuilder(_loggerFactory)
+                .Build();
+            using var pipeline = new PipelineBuilder(_loggerFactory)
+                .AddFlowElement(ipElement)
+                .AddFlowElement(codeTranslationElement)
+                .AddFlowElement(nameTranslationElement)
+                .Build();
+
+            using var flowData = pipeline.CreateFlowData();
+            flowData.AddEvidence("header.Accept-Language", "de_DE");
+            flowData.Process();
+
+            var result = flowData.Get<ICountriesTranslationData>();
+            var comparer = GetComparer(flowData, out var cultureUsed);
+
+            // Establish the baseline of all known countries from a list that
+            // never had any weighted codes injected.
+            var expectedCount = result.CountryCodesGeographicalAll.Value.Count;
+            Assert.IsTrue(expectedCount > 200);
+
+            AssertAllCountriesAlphabetical(
+                result.CountryCodesGeographicalAll.Value,
+                result.CountryNamesGeographicalAllTranslated.Value,
+                expectedCount, comparer, cultureUsed);
+            AssertAllCountriesAlphabetical(
+                result.CountryCodesPopulationAll.Value,
+                result.CountryNamesPopulationAllTranslated.Value,
+                expectedCount, comparer, cultureUsed);
+        }
+
+        /// <summary>
+        /// With a mix of a real code and the "Unknown" sentinel, the real
+        /// country leads and "Unknown" is dropped entirely; the remainder is
+        /// alphabetical.
+        /// </summary>
+        [TestMethod]
+        public void AllListsExcludeUnknownWhenMixedWithRealCode()
+        {
+            var ipElement = MockIpElement(
+                new[] { "DE", "Unknown" },
+                new[] { "DE", "Unknown" });
+            var codeTranslationElement =
+                new CountryCodeTranslationEngineBuilder(_loggerFactory)
+                .Build();
+            var nameTranslationElement =
+                new CountriesTranslationEngineBuilder(_loggerFactory)
+                .Build();
+            using var pipeline = new PipelineBuilder(_loggerFactory)
+                .AddFlowElement(ipElement)
+                .AddFlowElement(codeTranslationElement)
+                .AddFlowElement(nameTranslationElement)
+                .Build();
+
+            using var flowData = pipeline.CreateFlowData();
+            flowData.AddEvidence("header.Accept-Language", "de_DE");
+            flowData.Process();
+
+            var result = flowData.Get<ICountriesTranslationData>();
+            var comparer = GetComparer(flowData, out var cultureUsed);
+
+            var namesAll = result.CountryNamesGeographicalAllTranslated.Value;
+            var codesAll = result.CountryCodesGeographicalAll.Value;
+
+            // Real country leads.
+            Assert.AreEqual("DE", codesAll[0]);
+            Assert.AreEqual("Deutschland", namesAll[0]);
+
+            // "Unknown" must not appear in either list.
+            Assert.IsFalse(codesAll.Contains("Unknown"));
+            Assert.IsFalse(namesAll.Contains("Unknown"));
+
+            Assert.AreEqual(namesAll.Count, codesAll.Count);
+
+            // Remainder (after the single real code) is alphabetical by name.
+            var remaining = namesAll.Skip(1).ToList();
+            for (int i = 1; i < remaining.Count; i++)
+            {
+                Assert.IsTrue(
+                    comparer.Compare(remaining[i - 1], remaining[i]) <= 0,
+                    $"Expected '{remaining[i - 1]}' <= '{remaining[i]}' -- using '{cultureUsed}'");
+            }
+        }
+
+        private static void AssertAllCountriesAlphabetical(
+            IReadOnlyList<string> codes,
+            IReadOnlyList<string> names,
+            int expectedCount,
+            StringComparer comparer,
+            string cultureUsed)
+        {
+            Assert.AreEqual(expectedCount, codes.Count);
+            Assert.AreEqual(expectedCount, names.Count);
+            Assert.IsFalse(codes.Contains("Unknown"));
+            Assert.IsFalse(names.Contains("Unknown"));
+            for (int i = 1; i < names.Count; i++)
+            {
+                Assert.IsTrue(
+                    comparer.Compare(names[i - 1], names[i]) <= 0,
+                    $"Expected '{names[i - 1]}' <= '{names[i]}' -- using '{cultureUsed}'");
+            }
+        }
+
+        /// <summary>
         /// Test that the population "All" lists work independently from
         /// geographical "All" lists.
         /// </summary>


### PR DESCRIPTION
Fixes #254

On-premise `CountriesTranslationEngine` was prepending the IP engine's no-match sentinel ("Unknown") to every country "All" list. It's now filtered out, so a no-match yields all known countries ordered alphabetically.

## Changes
- Filter weighted tuples to real ISO codes (the curated `countrycodes.en_GB.yml` set) before building the "All" lists.
- Precompute the valid-code set once in the constructor instead of per request.
- Add tests for the no-real-codes and mixed (real + "Unknown") cases.