### PR TITLE
Align resource key and data file environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ to use the Cloud API, as described on our website. Get resource keys from
 our [configurator](https://configure.51degrees.com/), see our [documentation](https://51degrees.com/documentation/_concepts__configurator.html) on
 how to use this.
 
+The cloud property tiers changed in May 2026. Of the IP intelligence
+properties the examples display, the free tier includes only Country,
+LocationConfidence, Ip and IpV6, with a paid subscription needed for the
+rest, such as CountryCode, Region, Town, RegisteredName, Latitude and
+Longitude. A resource key selecting only the free tier properties can be
+created at https://configure.51degrees.com/Wkqxf3Bs, whilst
+https://configure.51degrees.com/hYzn3TV3 also includes the paid properties
+used by the examples. See https://51degrees.com/pricing to get a paid
+subscription with more properties.
+
 Examples and tests read the resource key from an environment variable called
 "51DEGREES_RESOURCE_KEY". The legacy environment variable names
 "51D_RESOURCE_KEY" and "SUPER_RESOURCE_KEY" are still supported, with the

--- a/README.md
+++ b/README.md
@@ -39,12 +39,28 @@ data file.
 
 [ip-intelligence-data](https://github.com/51Degrees/ip-intelligence-data/) submodule repository instructs how to obtain a 'Lite' data file, otherwise [contact us](https://51degrees.com/contact-us) to obtain an 'Enterprise' data file.
 
+Tests that need a data file locate it in the following order:
+
+1. The "51DEGREES_IPI_PATH" environment variable, which can be set to an
+   explicit path to the data file. The legacy "IPINTELLIGENCEDATAFILE"
+   environment variable is also still supported, and is checked after
+   "51DEGREES_IPI_PATH".
+2. A search of the folder hierarchy, walking up from the working directory,
+   for the expected data file name.
+3. The free 'Lite' data file in its expected location, which is the
+   ip-intelligence-data submodule of this repository.
+
 #### Cloud (coming soon)
 
 You will require [resource keys](https://51degrees.com/documentation/_info__resource_keys.html)
 to use the Cloud API, as described on our website. Get resource keys from
 our [configurator](https://configure.51degrees.com/), see our [documentation](https://51degrees.com/documentation/_concepts__configurator.html) on
 how to use this.
+
+Examples and tests read the resource key from an environment variable called
+"51DEGREES_RESOURCE_KEY". The legacy environment variable names
+"51D_RESOURCE_KEY" and "SUPER_RESOURCE_KEY" are still supported, with the
+aligned "51DEGREES_RESOURCE_KEY" name checked first.
 
 ## Solutions and projects
 

--- a/Tests/FiftyOne.IpIntelligence.CloudTests/CloudCountriesTranslationEngineTests.cs
+++ b/Tests/FiftyOne.IpIntelligence.CloudTests/CloudCountriesTranslationEngineTests.cs
@@ -43,7 +43,11 @@ namespace FiftyOne.IpIntelligence.CloudTests;
 public class CloudCountriesTranslationEngineTests
 {
     private IPipeline _pipeline;
-    private const string _resource_key_env_variable = "51D_RESOURCE_KEY";
+    // The aligned environment variable name is checked first. The legacy
+    // names are retained for backwards compatibility.
+    private const string _resource_key_env_variable = "51DEGREES_RESOURCE_KEY";
+    private const string _legacy_resource_key_env_variable = "51D_RESOURCE_KEY";
+    private const string _super_resource_key_env_variable = "SUPER_RESOURCE_KEY";
 
     /// <summary>
     /// Perform a simple gross error check by calling the cloud service
@@ -59,7 +63,11 @@ public class CloudCountriesTranslationEngineTests
     public void CloudIntegrationTest()
     {
         var resourceKey = System.Environment.GetEnvironmentVariable(
-            _resource_key_env_variable);
+            _resource_key_env_variable)
+            ?? System.Environment.GetEnvironmentVariable(
+                _legacy_resource_key_env_variable)
+            ?? System.Environment.GetEnvironmentVariable(
+                _super_resource_key_env_variable);
 
         if (resourceKey != null)
         {

--- a/Tests/FiftyOne.IpIntelligence.CloudTests/IpIntelligenceCloudEngineTests.cs
+++ b/Tests/FiftyOne.IpIntelligence.CloudTests/IpIntelligenceCloudEngineTests.cs
@@ -40,7 +40,11 @@ namespace FiftyOne.IpIntelligence.Cloud.Tests
     public class IpIntelligenceCloudEngineTests
     {
         private IPipeline _pipeline;
-        private const string _resource_key_env_variable = "51D_RESOURCE_KEY";
+        // The aligned environment variable name is checked first. The legacy
+        // names are retained for backwards compatibility.
+        private const string _resource_key_env_variable = "51DEGREES_RESOURCE_KEY";
+        private const string _legacy_resource_key_env_variable = "51D_RESOURCE_KEY";
+        private const string _super_resource_key_env_variable = "SUPER_RESOURCE_KEY";
 
         [TestInitialize]
         public void Init()
@@ -59,8 +63,12 @@ namespace FiftyOne.IpIntelligence.Cloud.Tests
         public void CloudIntegrationTest()
         {
             var resourceKey = System.Environment.GetEnvironmentVariable(
-                _resource_key_env_variable);
-        
+                _resource_key_env_variable)
+                ?? System.Environment.GetEnvironmentVariable(
+                    _legacy_resource_key_env_variable)
+                ?? System.Environment.GetEnvironmentVariable(
+                    _super_resource_key_env_variable);
+
             if (resourceKey != null)
             {
                 _pipeline = new IpiPipelineBuilder(

--- a/Tests/FiftyOne.IpIntelligence.Example.Tests.OnPremise/TestExamples.cs
+++ b/Tests/FiftyOne.IpIntelligence.Example.Tests.OnPremise/TestExamples.cs
@@ -60,9 +60,16 @@ namespace FiftyOne.IpIntelligence.Example.Tests.OnPremise
             LicenseKey = string.IsNullOrWhiteSpace(licenseKey) == false ?
                 licenseKey: "!!YOUR_LICENSE_KEY!!";
 
-            // Set Device Data file
+            // Set IP intelligence data file. The aligned '51DEGREES_IPI_PATH'
+            // environment variable is checked first, followed by the legacy
+            // 'IPINTELLIGENCEDATAFILE' name.
             DataFile = Environment.GetEnvironmentVariable(
-                Constants.IP_INTELLIGENCE_DATA_FILE_ENV_VAR);
+                "51DEGREES_IPI_PATH");
+            if (string.IsNullOrWhiteSpace(DataFile))
+            {
+                DataFile = Environment.GetEnvironmentVariable(
+                    "IPINTELLIGENCEDATAFILE");
+            }
             if (string.IsNullOrWhiteSpace(DataFile))
             {
                 DataFile = ExampleUtils.FindFile(

--- a/ci/run-performance-tests-console.ps1
+++ b/ci/run-performance-tests-console.ps1
@@ -46,6 +46,9 @@ $EnterpriseFile = [IO.Path]::Combine($EvidenceFiles, "51Degrees-EnterpriseIpiV41
 
 $env:IPINTELLIGENCEDATAFILE = (Get-ChildItem $EnterpriseFile).FullName
 # $env:IPINTELLIGENCEDATAFILE = (Get-ChildItem $EnterpriseFileDst).FullName
+# Aligned environment variable name. This is checked first by the examples
+# and tests. The legacy name above is retained for backwards compatibility.
+${env:51DEGREES_IPI_PATH} = $env:IPINTELLIGENCEDATAFILE
 Write-Debug "IPINTELLIGENCEDATAFILE = $env:IPINTELLIGENCEDATAFILE"
 
 # Write-Output "Moving evidence file"

--- a/ci/run-performance-tests-web.ps1
+++ b/ci/run-performance-tests-web.ps1
@@ -8,7 +8,9 @@ $PSNativeCommandUseErrorActionPreference = $true
 
 $perfTests = "$PSScriptRoot/../performance-tests"
 
-$env:PipelineOptions__Elements__0__BuildParameters__DataFile = $env:IPINTELLIGENCEDATAFILE
+# The aligned environment variable name is checked first. The legacy name is
+# retained for backwards compatibility.
+$env:PipelineOptions__Elements__0__BuildParameters__DataFile = ${env:51DEGREES_IPI_PATH} ?? $env:IPINTELLIGENCEDATAFILE
 
 dotnet build $perfTests -c $Configuration /p:Platform=$Arch
 try {

--- a/ci/setup-environment.ps1
+++ b/ci/setup-environment.ps1
@@ -28,7 +28,11 @@ if ($IsLinux) {
 }
 
 $env:IPINTELLIGENCEDATAFILE = [IO.Path]::Combine($RepoPath, "FiftyOne.IpIntelligence.Engine.OnPremise", "ip-intelligence-cxx", "ip-intelligence-data", "51Degrees-EnterpriseIpiV41.ipi")
+# Aligned environment variable name. This is checked first by the tests. The
+# legacy name above is retained for backwards compatibility.
+${env:51DEGREES_IPI_PATH} = $env:IPINTELLIGENCEDATAFILE
 # $env:SUPER_RESOURCE_KEY = $Keys.TestResourceKey
+# ${env:51DEGREES_RESOURCE_KEY} = $Keys.TestResourceKey
 # $env:DEVICEDETECTIONLICENSEKEY_DOTNET = $Keys.DeviceDetection
 # $env:ACCEPTCH_BROWSER_KEY = $Keys.AcceptCHBrowserKey
 # $env:ACCEPTCH_HARDWARE_KEY = $Keys.AcceptCHHardwareKey


### PR DESCRIPTION
## Summary

This change aligns the environment variable names used by the tests with the convention shared across 51Degrees repositories.

- The cloud tests read the resource key from `51DEGREES_RESOURCE_KEY` first. The legacy `51D_RESOURCE_KEY` and `SUPER_RESOURCE_KEY` names are retained and checked second.
- The example tests check `51DEGREES_IPI_PATH` for an explicit data file path first, then the legacy `IPINTELLIGENCEDATAFILE`, then the existing folder hierarchy search.
- Developer-facing messages now reference the aligned names and the README documents the resolution order.
- The CI scripts also set the aligned names, with the legacy assignments retained.

## Notes

- GitHub workflow secret references are unchanged. An accompanying issue advises on the aligned secret naming.
- The aligned names start with a digit, which POSIX shells do not accept in plain assignments. On Linux and macOS set them with the env command, for example `env 51DEGREES_RESOURCE_KEY=AAA dotnet test`.
