### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/.utm-lint.json
+++ b/.utm-lint.json
@@ -1,0 +1,3 @@
+{
+  "exclude": ["FiftyOne\\.IpIntelligence[^/]*/FiftyOne\\.IpIntelligence[^/]*\\.xml$"]
+}

--- a/FiftyOne.IpIntelligence.Cloud/FiftyOne.IpIntelligence.Cloud.csproj
+++ b/FiftyOne.IpIntelligence.Cloud/FiftyOne.IpIntelligence.Cloud.csproj
@@ -10,7 +10,7 @@
     <Authors>51Degrees Engineering</Authors>
     <Copyright>51Degrees Mobile Experts Limited</Copyright>
     <PackageLicenseExpression>EUPL-1.2</PackageLicenseExpression>
-    <PackageProjectUrl>www.51degrees.com</PackageProjectUrl>
+    <PackageProjectUrl>https://51degrees.com?utm_source=nuget&amp;utm_medium=package&amp;utm_campaign=ip-intelligence-dotnet&amp;utm_content=fiftyone.ipintelligence.cloud-fiftyone.ipintelligence.cloud.csproj&amp;utm_term=packageprojecturl</PackageProjectUrl>
     <PackageIcon>51d-logo.png</PackageIcon>
     <RepositoryUrl>https://github.com/51Degrees/ip-intelligence-dotnet</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/FiftyOne.IpIntelligence.Engine.OnPremise/Data/PropertyMetaDataIpi.cs
+++ b/FiftyOne.IpIntelligence.Engine.OnPremise/Data/PropertyMetaDataIpi.cs
@@ -110,7 +110,7 @@ namespace FiftyOne.IpIntelligence.Engine.OnPremise.Data
         /// </summary>
         /// <remarks>
         /// This is used by the 51Degrees Property Dictionary: 
-        /// https://51degrees.com/resources/property-dictionary and is 
+        /// https://51degrees.com/resources/property-dictionary?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=ip-intelligence-dotnet&amp;utm_content=fiftyone.ipintelligence.engine.onpremise-data-propertymetadataipi.cs&amp;utm_term=show and is 
         /// made available for customers should they wish to make use of it.
         /// </remarks>
         public bool Show { get; }
@@ -123,7 +123,7 @@ namespace FiftyOne.IpIntelligence.Engine.OnPremise.Data
         /// </summary>
         /// <remarks>
         /// This is used by the 51Degrees Property Dictionary: 
-        /// https://51degrees.com/resources/property-dictionary and is 
+        /// https://51degrees.com/resources/property-dictionary?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=ip-intelligence-dotnet&amp;utm_content=fiftyone.ipintelligence.engine.onpremise-data-propertymetadataipi.cs&amp;utm_term=showvalues and is 
         /// made available for customers should they wish to make use of it.
         /// </remarks>
         public bool ShowValues { get; }

--- a/FiftyOne.IpIntelligence.Engine.OnPremise/FiftyOne.IpIntelligence.Engine.OnPremise.csproj
+++ b/FiftyOne.IpIntelligence.Engine.OnPremise/FiftyOne.IpIntelligence.Engine.OnPremise.csproj
@@ -18,7 +18,7 @@
     <Copyright>51Degrees Mobile Experts Limited</Copyright>
     <PackageTags>51degrees;pipeline;pipeline-api;ip-intelligence;ip;ip-address;ip-geolocation;geolocation;geoip;engine;on-premise;onprem;local;offline</PackageTags>
     <RepositoryUrl>https://github.com/51Degrees/ip-intelligence-dotnet</RepositoryUrl>
-    <PackageProjectUrl>www.51degrees.com</PackageProjectUrl>
+    <PackageProjectUrl>https://51degrees.com?utm_source=nuget&amp;utm_medium=package&amp;utm_campaign=ip-intelligence-dotnet&amp;utm_content=fiftyone.ipintelligence.engine.onpremise-fiftyone.ipintelligence.engine.onpremise.csproj&amp;utm_term=packageprojecturl</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <PackageIcon>51d-logo.png</PackageIcon>
     <NeutralLanguage>en</NeutralLanguage>

--- a/FiftyOne.IpIntelligence.Shared/FiftyOne.IpIntelligence.Shared.csproj
+++ b/FiftyOne.IpIntelligence.Shared/FiftyOne.IpIntelligence.Shared.csproj
@@ -19,7 +19,7 @@
     <Copyright>51Degrees Mobile Experts Limited</Copyright>
     <PackageTags>51degrees;pipeline;pipeline-api;ip-intelligence;ip;ip-address;shared;common;models;utilities</PackageTags>
     <RepositoryUrl>https://github.com/51Degrees/ip-intelligence-dotnet</RepositoryUrl>
-    <PackageProjectUrl>www.51degrees.com</PackageProjectUrl>
+    <PackageProjectUrl>https://51degrees.com?utm_source=nuget&amp;utm_medium=package&amp;utm_campaign=ip-intelligence-dotnet&amp;utm_content=fiftyone.ipintelligence.shared-fiftyone.ipintelligence.shared.csproj&amp;utm_term=packageprojecturl</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <PackageIcon>51d-logo.png</PackageIcon>
     <NeutralLanguage>en</NeutralLanguage>

--- a/FiftyOne.IpIntelligence.Translation/FiftyOne.IpIntelligence.Translation.csproj
+++ b/FiftyOne.IpIntelligence.Translation/FiftyOne.IpIntelligence.Translation.csproj
@@ -18,7 +18,7 @@
     <Copyright>51Degrees Mobile Experts Limited</Copyright>
     <PackageTags>51degrees;pipeline;pipeline-api;ip-intelligence;language;translation</PackageTags>
     <RepositoryUrl>https://github.com/51Degrees/ip-intelligence-dotnet</RepositoryUrl>
-    <PackageProjectUrl>www.51degrees.com</PackageProjectUrl>
+    <PackageProjectUrl>https://51degrees.com?utm_source=nuget&amp;utm_medium=package&amp;utm_campaign=ip-intelligence-dotnet&amp;utm_content=fiftyone.ipintelligence.translation-fiftyone.ipintelligence.translation.csproj&amp;utm_term=packageprojecturl</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <PackageIcon>51d-logo.png</PackageIcon>
     <NeutralLanguage>en</NeutralLanguage>

--- a/FiftyOne.IpIntelligence/FiftyOne.IpIntelligence.csproj
+++ b/FiftyOne.IpIntelligence/FiftyOne.IpIntelligence.csproj
@@ -19,7 +19,7 @@
 	<Copyright>51Degrees Mobile Experts Limited</Copyright>
 	<PackageTags>51degrees;pipeline;pipeline-api;pipeline-builder;builder;configuration;ip-intelligence;ip;ip-address;ip-geolocation;geolocation;geoip;asn;autonomous-system;isp;organization;network</PackageTags>
 	<RepositoryUrl>https://github.com/51Degrees/ip-intelligence-dotnet</RepositoryUrl>
-	<PackageProjectUrl>www.51degrees.com</PackageProjectUrl>
+	<PackageProjectUrl>https://51degrees.com?utm_source=nuget&amp;utm_medium=package&amp;utm_campaign=ip-intelligence-dotnet&amp;utm_content=fiftyone.ipintelligence-fiftyone.ipintelligence.csproj&amp;utm_term=packageprojecturl</PackageProjectUrl>
 	<RepositoryType>git</RepositoryType>
 	<PackageIcon>51d-logo.png</PackageIcon>
 	<NeutralLanguage>en</NeutralLanguage>

--- a/FiftyOne.IpIntelligence/IpiPipelineBuilder.cs
+++ b/FiftyOne.IpIntelligence/IpiPipelineBuilder.cs
@@ -102,7 +102,7 @@ namespace FiftyOne.IpIntelligence
         /// </summary>
         /// <param name="resourceKey">
         /// The resource key to use when querying the Cloud service. 
-        /// Obtain one from https://configure.51degrees.com
+        /// Obtain one from https://configure.51degrees.com?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=ip-intelligence-dotnet&amp;utm_content=fiftyone.ipintelligence-ipipipelinebuilder.cs&amp;utm_term=usecloud
         /// </param>
         /// <returns>
         /// A builder that can be used to configure and build a pipeline
@@ -120,7 +120,7 @@ namespace FiftyOne.IpIntelligence
         /// </summary>
         /// <param name="resourceKey">
         /// The resource key to use when querying the Cloud service. 
-        /// Obtain one from https://configure.51degrees.com
+        /// Obtain one from https://configure.51degrees.com?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=ip-intelligence-dotnet&amp;utm_content=fiftyone.ipintelligence-ipipipelinebuilder.cs&amp;utm_term=usecloud-2
         /// </param>
         /// <param name="endpoint">
         /// The 51Degrees Cloud URL.
@@ -180,7 +180,7 @@ namespace FiftyOne.IpIntelligence
         /// The license key to use when checking for updates to the
         /// data file.
         /// A license key can be obtained from the 
-        /// [51Degrees website](https://www.51degrees.com/pricing).
+        /// [51Degrees website](https://51degrees.com/pricing?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=ip-intelligence-dotnet&amp;utm_content=fiftyone.ipintelligence-ipipipelinebuilder.cs&amp;utm_term=useonpremise).
         /// If you have no license key then this parameter can be 
         /// set to null, but doing so will disable automatic updates. 
         /// </param>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # 51Degrees IP Intelligence Engines
 
-![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=dotnet-open-source "Data rewards the curious") **Pipeline API**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-dotnet&utm_content=readme.md&utm_term=51degrees-ip-intelligence-engines "Data rewards the curious") **Pipeline API**
 
-[Developer Documentation](https://51degrees.com/ip-intelligence-dotnet/4.1/index.html "developer documentation")
+[Developer Documentation](https://51degrees.com/ip-intelligence-dotnet/4.1/index.html?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-dotnet&utm_content=readme.md&utm_term=51degrees-ip-intelligence-engines "developer documentation")
 
 ## Introduction
 
@@ -23,7 +23,7 @@ projects mostly target .NET 8.0 though in some cases, projects are available
 targeting other frameworks.
 
 For runtime dependencies, see our
-[dependencies](https://51degrees.com/documentation/_info__dependencies.html)
+[dependencies](https://51degrees.com/documentation/_info__dependencies.html?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-dotnet&utm_content=readme.md&utm_term=dependencies)
 page. The `ci/options.json` file lists the tested and packaged .NET versions
 and operating systems automatic tests are performed with. The solution will
 likely operate with other versions.
@@ -37,13 +37,13 @@ The API does detections using a local (on-premise) data file or cloud service (c
 In order to perform IP intelligence on-premise, you will need to use a
 data file.
 
-[ip-intelligence-data](https://github.com/51Degrees/ip-intelligence-data/) submodule repository instructs how to obtain a 'Lite' data file, otherwise [contact us](https://51degrees.com/contact-us) to obtain an 'Enterprise' data file.
+[ip-intelligence-data](https://github.com/51Degrees/ip-intelligence-data/) submodule repository instructs how to obtain a 'Lite' data file, otherwise [contact us](https://51degrees.com/contact-us?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-dotnet&utm_content=readme.md&utm_term=on-premise) to obtain an 'Enterprise' data file.
 
 #### Cloud (coming soon)
 
-You will require [resource keys](https://51degrees.com/documentation/_info__resource_keys.html)
+You will require [resource keys](https://51degrees.com/documentation/_info__resource_keys.html?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-dotnet&utm_content=readme.md&utm_term=cloud-coming-soon)
 to use the Cloud API, as described on our website. Get resource keys from
-our [configurator](https://configure.51degrees.com/), see our [documentation](https://51degrees.com/documentation/_concepts__configurator.html) on
+our [configurator](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-dotnet&utm_content=readme.md&utm_term=cloud-coming-soon), see our [documentation](https://51degrees.com/documentation/_concepts__configurator.html?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-dotnet&utm_content=readme.md&utm_term=cloud-coming-soon) on
 how to use this.
 
 ## Solutions and projects
@@ -149,10 +149,10 @@ Visual Studio or by using the `dotnet test` command line tool.
 Some tests require additional resources to run. These will either fail or return
 an 'inconclusive' result if these resources are not provided.
 
-- Some tests require an 'Enterprise' data file. This can be obtained by [purchasing a license](https://51degrees.com/pricing).
-- Tests using the Cloud service require resource keys with specific properties. A [license](https://51degrees.com/pricing) is required in order to access some properties.
+- Some tests require an 'Enterprise' data file. This can be obtained by [purchasing a license](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-dotnet&utm_content=readme.md&utm_term=tests).
+- Tests using the Cloud service require resource keys with specific properties. A [license](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-dotnet&utm_content=readme.md&utm_term=tests-2) is required in order to access some properties.
 
 ## Project documentation
 
 For complete documentation on the Pipeline API and associated engines, see the
-[51Degrees documentation site](https://51degrees.com/documentation/index.html).
+[51Degrees documentation site](https://51degrees.com/documentation/index.html?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-dotnet&utm_content=readme.md&utm_term=project-documentation).


### PR DESCRIPTION
## Summary

Every navigational 51degrees.com and configure.51degrees.com link in this repository now carries the standard UTM query string so the Content Team can trace Matomo campaign traffic to the exact repository, file, and location it came from:

`?utm_source=<github|code|nuget|npm|maven|packagist>&utm_medium=<readme|docs|example|comment|package>&utm_campaign=<repository>&utm_content=<file slug>&utm_term=<location in file>`

20 links across 10 files, in-place URL replacements only. While tagging, www and http variants were normalised to https on the bare domain (including the five PackageProjectUrl values), the old utm scheme on the README was replaced, and functional endpoints, test fixtures, license headers, and generated files are untouched.

## Lint

A second commit adds the utm-link-lint workflow, which runs the shared script from 51Degrees/common-ci on pull requests and pushes to main, keeping the convention enforced from now on. An accompanying .utm-lint.json excludes the committed compiler-generated documentation XML, which picks the tagged URLs up at the next build. The lint check on this PR stays red until 51Degrees/common-ci#207 merges, since the workflow fetches the script from that repository's main.

The full convention is documented in UTM-LINK-TAGGING.md in 51Degrees/internal-common-ci (PR 3).