### PR TITLE
Align env var names with the main repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ data file.
 
 Tests that need a data file locate it in the following order:
 
-1. The "51DEGREES_IPI_PATH" environment variable, which can be set to an
+1. The "_51DEGREES_IPI_PATH" environment variable, which can be set to an
    explicit path to the data file. The legacy "IPINTELLIGENCEDATAFILE"
    environment variable is also still supported, and is checked after
-   "51DEGREES_IPI_PATH".
+   "_51DEGREES_IPI_PATH".
 2. A search of the folder hierarchy, walking up from the working directory,
    for the expected data file name.
 3. The free 'Lite' data file in its expected location, which is the
@@ -68,9 +68,9 @@ used by the examples. See [https://51degrees.com/pricing](https://51degrees.com/
 subscription with more properties.
 
 Examples and tests read the resource key from an environment variable called
-"51DEGREES_RESOURCE_KEY". The legacy environment variable names
+"_51DEGREES_RESOURCE_KEY". The legacy environment variable names
 "51D_RESOURCE_KEY" and "SUPER_RESOURCE_KEY" are still supported, with the
-aligned "51DEGREES_RESOURCE_KEY" name checked first.
+aligned "_51DEGREES_RESOURCE_KEY" name checked first.
 
 ## Solutions and projects
 

--- a/Tests/FiftyOne.IpIntelligence.CloudTests/CloudCountriesTranslationEngineTests.cs
+++ b/Tests/FiftyOne.IpIntelligence.CloudTests/CloudCountriesTranslationEngineTests.cs
@@ -45,7 +45,7 @@ public class CloudCountriesTranslationEngineTests
     private IPipeline _pipeline;
     // The aligned environment variable name is checked first. The legacy
     // names are retained for backwards compatibility.
-    private const string _resource_key_env_variable = "51DEGREES_RESOURCE_KEY";
+    private const string _resource_key_env_variable = "_51DEGREES_RESOURCE_KEY";
     private const string _legacy_resource_key_env_variable = "51D_RESOURCE_KEY";
     private const string _super_resource_key_env_variable = "SUPER_RESOURCE_KEY";
 

--- a/Tests/FiftyOne.IpIntelligence.CloudTests/IpIntelligenceCloudEngineTests.cs
+++ b/Tests/FiftyOne.IpIntelligence.CloudTests/IpIntelligenceCloudEngineTests.cs
@@ -42,7 +42,7 @@ namespace FiftyOne.IpIntelligence.Cloud.Tests
         private IPipeline _pipeline;
         // The aligned environment variable name is checked first. The legacy
         // names are retained for backwards compatibility.
-        private const string _resource_key_env_variable = "51DEGREES_RESOURCE_KEY";
+        private const string _resource_key_env_variable = "_51DEGREES_RESOURCE_KEY";
         private const string _legacy_resource_key_env_variable = "51D_RESOURCE_KEY";
         private const string _super_resource_key_env_variable = "SUPER_RESOURCE_KEY";
 
@@ -79,7 +79,7 @@ namespace FiftyOne.IpIntelligence.Cloud.Tests
                 data.AddEvidence("query.client-ip-51d",
                     "185.28.167.78");
                 data.Process();
-        
+
                 var ipData = data.Get<IIpIntelligenceData>();
                 Assert.IsNotNull(ipData);
                 Assert.IsTrue(ipData.CountryCode.HasValue);
@@ -92,18 +92,18 @@ namespace FiftyOne.IpIntelligence.Cloud.Tests
         }
 
 
-        // TODO - The commented out section below is more how we should be testing. 
+        // TODO - The commented out section below is more how we should be testing.
         // i.e. not relying on the cloud request engine actually making a request.
         // Unfortunatley, everything its too tightly coupled for this to work right now.
-        // 
+        //
         // private IpiCloudEngine _engine;
         // private TestLoggerFactory _loggerFactory;
         // private Mock<IPipeline> _pipeline;
-        // 
+        //
         // private int _maxWarnings = 0;
         // private int _maxErrors = 0;
         // private string _testJson = "";
-        // 
+        //
         // [TestInitialize]
         // public void Init()
         // {
@@ -113,7 +113,7 @@ namespace FiftyOne.IpIntelligence.Cloud.Tests
         //         CreateIpData);
         //     _pipeline = new Mock<IPipeline>();
         // }
-        // 
+        //
         // private IpDataCloud CreateIpData(IPipeline pipeline, FlowElementBase<IpDataCloud, IAspectPropertyMetaData> engine)
         // {
         //     return new IpDataCloud(
@@ -128,14 +128,14 @@ namespace FiftyOne.IpIntelligence.Cloud.Tests
         //     data.JsonResponse = _testJson;
         //     return data;
         // }
-        // 
+        //
         // [TestCleanup]
         // public void Cleanup()
         // {
         //     _loggerFactory.AssertMaxErrors(_maxErrors);
         //     _loggerFactory.AssertMaxWarnings(_maxWarnings);
         // }
-        // 
+        //
         // [TestMethod]
         // public void TestMethod1()
         // {
@@ -189,10 +189,10 @@ namespace FiftyOne.IpIntelligence.Cloud.Tests
         //     }";
         //     TestPipeline pipeline = new TestPipeline(_pipeline.Object);
         //     TestFlowData testData = new TestFlowData(_loggerFactory.CreateLogger<TestFlowData>(), pipeline);
-        // 
+        //
         //     testData.GetOrAdd("cloudrequestdata", CreateTestData);
         //     _engine.Process(testData);
-        // 
+        //
         //     var result = testData.Get<IIpIntelligenceData>();
         //     Assert.IsNotNull(result);
         // }

--- a/Tests/FiftyOne.IpIntelligence.Example.Tests.OnPremise/TestExamples.cs
+++ b/Tests/FiftyOne.IpIntelligence.Example.Tests.OnPremise/TestExamples.cs
@@ -32,8 +32,8 @@ namespace FiftyOne.IpIntelligence.Example.Tests.OnPremise
     /// This test class ensures that the hash examples execute successfully.
     /// </summary>
     /// <remarks>
-    /// Note that these test do not generally ensure the correctness 
-    /// of the example, only that the example will run without 
+    /// Note that these test do not generally ensure the correctness
+    /// of the example, only that the example will run without
     /// crashing or throwing any unhandled exceptions.
     /// </remarks>
     [TestClass]
@@ -46,7 +46,7 @@ namespace FiftyOne.IpIntelligence.Example.Tests.OnPremise
         private string EvidenceFile;
 
         /// <summary>
-        /// Init method - specify License Key to run examples here or 
+        /// Init method - specify License Key to run examples here or
         /// set a License Key in an environment variable called 'ResourceKey'.
         /// Set data file for hash examples and additionally a User-Agents file
         /// for the performance example.
@@ -60,11 +60,11 @@ namespace FiftyOne.IpIntelligence.Example.Tests.OnPremise
             LicenseKey = string.IsNullOrWhiteSpace(licenseKey) == false ?
                 licenseKey: "!!YOUR_LICENSE_KEY!!";
 
-            // Set IP intelligence data file. The aligned '51DEGREES_IPI_PATH'
+            // Set IP intelligence data file. The aligned '_51DEGREES_IPI_PATH'
             // environment variable is checked first, followed by the legacy
             // 'IPINTELLIGENCEDATAFILE' name.
             DataFile = Environment.GetEnvironmentVariable(
-                "51DEGREES_IPI_PATH");
+                "_51DEGREES_IPI_PATH");
             if (string.IsNullOrWhiteSpace(DataFile))
             {
                 DataFile = Environment.GetEnvironmentVariable(

--- a/ci/run-performance-tests-console.ps1
+++ b/ci/run-performance-tests-console.ps1
@@ -41,15 +41,11 @@ if ($(Test-Path -Path $ExamplesRepoName) -eq $False) {
 
 # Write-Output "Moving enterprise IPI file"
 $EnterpriseFile = [IO.Path]::Combine($EvidenceFiles, "51Degrees-EnterpriseIpiV41.ipi")
-# $EnterpriseFileDst = "ip-intelligence-dotnet-examples/ip-intelligence-data/51Degrees-EnterpriseIpiV41.ipi" 
+# $EnterpriseFileDst = "ip-intelligence-dotnet-examples/ip-intelligence-data/51Degrees-EnterpriseIpiV41.ipi"
 # Move-Item -Force $EnterpriseFile $EnterpriseFileDst
 
-$env:IPINTELLIGENCEDATAFILE = (Get-ChildItem $EnterpriseFile).FullName
-# $env:IPINTELLIGENCEDATAFILE = (Get-ChildItem $EnterpriseFileDst).FullName
-# Aligned environment variable name. This is checked first by the examples
-# and tests. The legacy name above is retained for backwards compatibility.
-${env:51DEGREES_IPI_PATH} = $env:IPINTELLIGENCEDATAFILE
-Write-Debug "IPINTELLIGENCEDATAFILE = $env:IPINTELLIGENCEDATAFILE"
+$env:_51DEGREES_IPI_PATH = (Get-ChildItem $EnterpriseFile).FullName
+Write-Debug "_51DEGREES_IPI_PATH = $env:_51DEGREES_IPI_PATH"
 
 # Write-Output "Moving evidence file"
 $EvidenceFile = [IO.Path]::Combine($EvidenceFiles, "evidence.yml")
@@ -62,7 +58,7 @@ function Edit-ExamplesCsprojRef {
         [string]$PackageInfix = "",
         [string]$ProjectInfix = ""
     )
-    
+
     $ExampleProject = [IO.Path]::Combine($ExamplesRepoPath, "Examples", "FiftyOne.IpIntelligence.Examples$ExampleInfix")
     $IpIntelligenceProject = [IO.Path]::Combine($RepoPath, "FiftyOne.IpIntelligence$ProjectInfix", "FiftyOne.IpIntelligence$ProjectInfix.csproj")
 
@@ -127,7 +123,7 @@ try {
     finally {
         Pop-Location
     }
-    
+
     if ($LASTEXITCODE -ne 0) {
         Write-Error "LASTEXITCODE = $LASTEXITCODE"
     }

--- a/ci/run-performance-tests-web.ps1
+++ b/ci/run-performance-tests-web.ps1
@@ -10,7 +10,7 @@ $perfTests = "$PSScriptRoot/../performance-tests"
 
 # The aligned environment variable name is checked first. The legacy name is
 # retained for backwards compatibility.
-$env:PipelineOptions__Elements__0__BuildParameters__DataFile = ${env:51DEGREES_IPI_PATH} ?? $env:IPINTELLIGENCEDATAFILE
+$env:PipelineOptions__Elements__0__BuildParameters__DataFile = $env:_51DEGREES_IPI_PATH
 
 dotnet build $perfTests -c $Configuration /p:Platform=$Arch
 try {

--- a/ci/setup-environment.ps1
+++ b/ci/setup-environment.ps1
@@ -27,14 +27,4 @@ if ($IsLinux) {
 
 }
 
-$env:IPINTELLIGENCEDATAFILE = [IO.Path]::Combine($RepoPath, "FiftyOne.IpIntelligence.Engine.OnPremise", "ip-intelligence-cxx", "ip-intelligence-data", "51Degrees-EnterpriseIpiV41.ipi")
-# Aligned environment variable name. This is checked first by the tests. The
-# legacy name above is retained for backwards compatibility.
-${env:51DEGREES_IPI_PATH} = $env:IPINTELLIGENCEDATAFILE
-# $env:SUPER_RESOURCE_KEY = $Keys.TestResourceKey
-# ${env:51DEGREES_RESOURCE_KEY} = $Keys.TestResourceKey
-# $env:DEVICEDETECTIONLICENSEKEY_DOTNET = $Keys.DeviceDetection
-# $env:ACCEPTCH_BROWSER_KEY = $Keys.AcceptCHBrowserKey
-# $env:ACCEPTCH_HARDWARE_KEY = $Keys.AcceptCHHardwareKey
-# $env:ACCEPTCH_PLATFORM_KEY = $Keys.AcceptCHPlatformKey
-# $env:ACCEPTCH_NONE_KEY = $Keys.AcceptCHNoneKey
+$env:_51DEGREES_IPI_PATH = [IO.Path]::Combine($RepoPath, "FiftyOne.IpIntelligence.Engine.OnPremise", "ip-intelligence-cxx", "ip-intelligence-data", "51Degrees-EnterpriseIpiV41.ipi")


### PR DESCRIPTION
`device-detection-dotnet` switched to underscore-prefixed 51DEGREES variables to avoid issues with software that expects them to be valid identifier.