### PR TITLE
Handle failed cloud requests gracefully in IPI cloud and translation engines

### DIFF
--- a/FiftyOne.IpIntelligence.Cloud/FiftyOne.IpIntelligence.Cloud.xml
+++ b/FiftyOne.IpIntelligence.Cloud/FiftyOne.IpIntelligence.Cloud.xml
@@ -217,26 +217,32 @@
             from the <see cref="T:FiftyOne.Pipeline.CloudRequestEngine.FlowElements.ICloudRequestEngine"/>.
             </summary>
         </member>
-        <member name="M:FiftyOne.IpIntelligence.Cloud.FlowElements.IpiCloudEngine.ProcessEngine(FiftyOne.Pipeline.Core.Data.IFlowData,FiftyOne.IpIntelligence.Cloud.Data.IpDataCloud)">
-            <summary>
-            Perform the processing for this engine:
-            1. Get the JSON data from the <see cref="T:FiftyOne.Pipeline.CloudRequestEngine.FlowElements.CloudRequestEngine"/> 
-            response.
-            2. Extract properties relevant to this engine.
-            3. Deserialize JSON data to populate a 
-            <see cref="T:FiftyOne.IpIntelligence.Cloud.Data.IpDataCloud"/> instance.
-            </summary>
-            <param name="data">
-            The <see cref="T:FiftyOne.Pipeline.Core.Data.IFlowData"/> instance containing data for the 
-            current request.
-            </param>
-            <param name="aspectData">
-            The <see cref="T:FiftyOne.IpIntelligence.Cloud.Data.IpDataCloud"/> instance to populate with
-            values.
-            </param>
-            <exception cref="T:System.ArgumentNullException">
-            Thrown if a required parameter is null
-            </exception>
+        <member name="M:FiftyOne.IpIntelligence.Cloud.FlowElements.IpiCloudEngine.ProcessCloudEngine(FiftyOne.Pipeline.Core.Data.IFlowData,FiftyOne.IpIntelligence.Cloud.Data.IpDataCloud,System.String)">
+             <summary>
+             Perform the processing for this engine:
+             1. Extract the "ip" section from the cloud JSON.
+             2. Deserialize it to populate a <see cref="T:FiftyOne.IpIntelligence.Cloud.Data.IpDataCloud"/>
+             instance.
+            
+             The base <see cref="T:FiftyOne.Pipeline.CloudRequestEngine.FlowElements.CloudAspectEngineBase`1"/> handles fetching
+             the JSON from the <see cref="T:FiftyOne.Pipeline.CloudRequestEngine.FlowElements.CloudRequestEngine"/>, the
+             missing-engine error and the empty-response (cloud request
+             failed) case, then calls this method with the JSON.
+             </summary>
+             <param name="data">
+             The <see cref="T:FiftyOne.Pipeline.Core.Data.IFlowData"/> instance containing data for the
+             current request.
+             </param>
+             <param name="aspectData">
+             The <see cref="T:FiftyOne.IpIntelligence.Cloud.Data.IpDataCloud"/> instance to populate with
+             values.
+             </param>
+             <param name="json">
+             The JSON response from the <see cref="T:FiftyOne.Pipeline.CloudRequestEngine.FlowElements.CloudRequestEngine"/>.
+             </param>
+             <exception cref="T:System.ArgumentNullException">
+             Thrown if a required parameter is null
+             </exception>
         </member>
         <member name="M:FiftyOne.IpIntelligence.Cloud.FlowElements.IpiCloudEngine.ToValueForAPV(System.Object,System.Type)">
             <summary>

--- a/FiftyOne.IpIntelligence.Cloud/FlowElements/IpiCloudEngine.cs
+++ b/FiftyOne.IpIntelligence.Cloud/FlowElements/IpiCloudEngine.cs
@@ -26,7 +26,6 @@ using FiftyOne.Pipeline.CloudRequestEngine.Data;
 using FiftyOne.Pipeline.CloudRequestEngine.FlowElements;
 using FiftyOne.Pipeline.Core.Data;
 using FiftyOne.Pipeline.Core.Data.Types;
-using FiftyOne.Pipeline.Core.Exceptions;
 using FiftyOne.Pipeline.Core.FlowElements;
 using FiftyOne.Pipeline.Engines.Data;
 using Microsoft.Extensions.Logging;
@@ -83,57 +82,47 @@ namespace FiftyOne.IpIntelligence.Cloud.FlowElements
 
         /// <summary>
         /// Perform the processing for this engine:
-        /// 1. Get the JSON data from the <see cref="CloudRequestEngine"/> 
-        /// response.
-        /// 2. Extract properties relevant to this engine.
-        /// 3. Deserialize JSON data to populate a 
-        /// <see cref="IpDataCloud"/> instance.
+        /// 1. Extract the "ip" section from the cloud JSON.
+        /// 2. Deserialize it to populate a <see cref="IpDataCloud"/>
+        /// instance.
+        ///
+        /// The base <see cref="CloudAspectEngineBase{T}"/> handles fetching
+        /// the JSON from the <see cref="CloudRequestEngine"/>, the
+        /// missing-engine error and the empty-response (cloud request
+        /// failed) case, then calls this method with the JSON.
         /// </summary>
         /// <param name="data">
-        /// The <see cref="IFlowData"/> instance containing data for the 
+        /// The <see cref="IFlowData"/> instance containing data for the
         /// current request.
         /// </param>
         /// <param name="aspectData">
         /// The <see cref="IpDataCloud"/> instance to populate with
         /// values.
         /// </param>
+        /// <param name="json">
+        /// The JSON response from the <see cref="CloudRequestEngine"/>.
+        /// </param>
         /// <exception cref="ArgumentNullException">
         /// Thrown if a required parameter is null
         /// </exception>
-        protected override void ProcessEngine(IFlowData data, IpDataCloud aspectData)
+        protected override void ProcessCloudEngine(IFlowData data, IpDataCloud aspectData, string json)
         {
-            if (data == null) { throw new ArgumentNullException(nameof(data)); }
             if (aspectData == null) { throw new ArgumentNullException(nameof(aspectData)); }
 
-            var requestData = data.GetFromElement(RequestEngine.GetInstance());
-            var json = requestData?.JsonResponse;
+            var dictionary = JsonConvert.DeserializeObject<Dictionary<string, object>>(json);
+            var propertyValues = JsonConvert.DeserializeObject<Dictionary<string, object>>(dictionary["ip"].ToString(),
+                new JsonSerializerSettings()
+                {
+                    Converters = JSON_CONVERTERS,
+                });
 
-            if (string.IsNullOrEmpty(json))
-            {
-                throw new PipelineConfigurationException(
-                    $"Json response from cloud request engine is null. " +
-                    $"This is probably because there is not a " +
-                    $"'CloudRequestEngine' before the '{GetType().Name}' " +
-                    $"in the Pipeline. This engine will be unable " +
-                    $"to produce results until this is corrected.");
-            }
-            else
-            {
-                var dictionary = JsonConvert.DeserializeObject<Dictionary<string, object>>(json);
-                var propertyValues = JsonConvert.DeserializeObject<Dictionary<string, object>>(dictionary["ip"].ToString(),
-                    new JsonSerializerSettings()
-                    {
-                        Converters = JSON_CONVERTERS,
-                    });
-
-                var ip = CloudDataHelper.CreateAPVDictionary(
-                    propertyValues,
-                    Properties.ToList(),
-                    CloudDataHelper.IpTypeConverter,
-                    Logger,
-                    GetType().Name);
-                aspectData.PopulateFrom(ip);
-            }
+            var ip = CloudDataHelper.CreateAPVDictionary(
+                propertyValues,
+                Properties.ToList(),
+                CloudDataHelper.IpTypeConverter,
+                Logger,
+                GetType().Name);
+            aspectData.PopulateFrom(ip);
         }
 
         /// <summary>

--- a/FiftyOne.IpIntelligence.Translation/FiftyOne.IpIntelligence.Translation.xml
+++ b/FiftyOne.IpIntelligence.Translation/FiftyOne.IpIntelligence.Translation.xml
@@ -202,6 +202,13 @@
         <member name="M:FiftyOne.IpIntelligence.Translation.FlowElements.CountriesTranslationEngine.ProcessInternal(FiftyOne.Pipeline.Core.Data.IFlowData)">
             <inheritdoc/>
         </member>
+        <member name="M:FiftyOne.IpIntelligence.Translation.FlowElements.CountriesTranslationEngine.GetWeightedOrEmpty(FiftyOne.IpIntelligence.Translation.Data.ICountriesTranslationData,System.String)">
+            <summary>
+            Reads a weighted string list property from the element data,
+            returning an empty list when the property is absent, has no
+            value, or holds a differently typed no-value placeholder.
+            </summary>
+        </member>
         <member name="M:FiftyOne.IpIntelligence.Translation.FlowElements.CountriesTranslationEngine.BuildAndStoreAllLists(FiftyOne.IpIntelligence.Translation.Data.ICountriesTranslationData,System.Collections.Generic.IReadOnlyList{FiftyOne.Pipeline.Core.Data.IWeightedValue{System.String}},System.Collections.Generic.IReadOnlyList{FiftyOne.Pipeline.Core.Data.IWeightedValue{System.String}},FiftyOne.Pipeline.Translation.Data.Translator,System.StringComparer,System.String,System.String)">
             <summary>
             Builds the complete "All" lists for one dimension (geographical

--- a/FiftyOne.IpIntelligence.Translation/FlowElements/CountriesTranslationEngine.cs
+++ b/FiftyOne.IpIntelligence.Translation/FlowElements/CountriesTranslationEngine.cs
@@ -23,6 +23,7 @@
 using FiftyOne.IpIntelligence.Translation.Data;
 using FiftyOne.Pipeline.Core.Data;
 using FiftyOne.Pipeline.Core.FlowElements;
+using FiftyOne.Pipeline.Engines;
 using FiftyOne.Pipeline.Engines.Data;
 using FiftyOne.Pipeline.Translation.Data;
 using FiftyOne.Pipeline.Translation.FlowElements;
@@ -178,7 +179,10 @@ namespace FiftyOne.IpIntelligence.Translation.FlowElements
 
             elementData[nameof(CountriesTranslationData.SortingCultureUsed)] = cultureUsed;
 
-            // Get weighted codes from IP engine.
+            // Get weighted codes from IP engine. The IP data or either
+            // property can be absent, most commonly when the cloud request
+            // failed, so treat every "not there" signal as no value rather
+            // than letting it escape as a per-request exception.
             IAspectPropertyValue<IReadOnlyList<IWeightedValue<string>>> geoCodesWeighted = null;
             IAspectPropertyValue<IReadOnlyList<IWeightedValue<string>>> popCodesWeighted = null;
             IIpIntelligenceData ipData = null;
@@ -190,17 +194,26 @@ namespace FiftyOne.IpIntelligence.Translation.FlowElements
             }
             catch (KeyNotFoundException) { }
             catch (PipelineException) { }
+            catch (PropertyMissingException) { }
 
-            // Get the weighted names (translated or pass-through English).
-            var geoTranslated = elementData.CountryNamesGeographicalTranslated;
-            var popTranslated = elementData.CountryNamesPopulationTranslated;
+            // Get the weighted names (translated or pass-through English)
+            // written by the base class. When the source properties were
+            // missing the base stores a no-value placeholder that is not
+            // necessarily of the weighted list type, so read defensively
+            // rather than through the typed getters.
+            var geoTranslated = GetWeightedOrEmpty(
+                elementData,
+                nameof(ICountriesTranslationData
+                    .CountryNamesGeographicalTranslated));
+            var popTranslated = GetWeightedOrEmpty(
+                elementData,
+                nameof(ICountriesTranslationData
+                    .CountryNamesPopulationTranslated));
 
             BuildAndStoreAllLists(
                 elementData,
-                geoTranslated.HasValue 
-                    ? geoTranslated.Value
-                    : Array.Empty<IWeightedValue<string>>(),
-                geoCodesWeighted.HasValue 
+                geoTranslated,
+                geoCodesWeighted?.HasValue == true
                     ? geoCodesWeighted.Value
                     : Array.Empty<IWeightedValue<string>>(),
                 translator, comparer,
@@ -211,10 +224,8 @@ namespace FiftyOne.IpIntelligence.Translation.FlowElements
 
             BuildAndStoreAllLists(
                 elementData,
-                popTranslated.HasValue 
-                    ? popTranslated.Value
-                    : Array.Empty<IWeightedValue<string>>(),
-                popCodesWeighted.HasValue 
+                popTranslated,
+                popCodesWeighted?.HasValue == true
                     ? popCodesWeighted.Value
                     : Array.Empty<IWeightedValue<string>>(),
                 translator, comparer,
@@ -222,6 +233,26 @@ namespace FiftyOne.IpIntelligence.Translation.FlowElements
                     .CountryNamesPopulationAllTranslated),
                 nameof(ICountriesTranslationData
                     .CountryCodesPopulationAll));
+        }
+
+        /// <summary>
+        /// Reads a weighted string list property from the element data,
+        /// returning an empty list when the property is absent, has no
+        /// value, or holds a differently typed no-value placeholder.
+        /// </summary>
+        private static IReadOnlyList<IWeightedValue<string>> GetWeightedOrEmpty(
+            ICountriesTranslationData elementData,
+            string propertyName)
+        {
+            if (elementData.AsDictionary()
+                    .TryGetValue(propertyName, out var value) &&
+                value is IAspectPropertyValue<
+                    IReadOnlyList<IWeightedValue<string>>> weighted &&
+                weighted.HasValue)
+            {
+                return weighted.Value;
+            }
+            return Array.Empty<IWeightedValue<string>>();
         }
 
         /// <summary>

--- a/Tests/FiftyOne.IpIntelligence.CloudTests/IpiCloudEngineProcessTests.cs
+++ b/Tests/FiftyOne.IpIntelligence.CloudTests/IpiCloudEngineProcessTests.cs
@@ -1,0 +1,211 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using FiftyOne.Common.TestHelpers;
+using FiftyOne.IpIntelligence.Cloud.Data;
+using FiftyOne.IpIntelligence.Cloud.FlowElements;
+using FiftyOne.Pipeline.CloudRequestEngine.Data;
+using FiftyOne.Pipeline.CloudRequestEngine.FlowElements;
+using FiftyOne.Pipeline.CloudRequestEngine.Services;
+using FiftyOne.Pipeline.Core.Data;
+using FiftyOne.Pipeline.Core.FlowElements;
+using FiftyOne.Pipeline.Core.TypedMap;
+using FiftyOne.Pipeline.Engines.Data;
+using FiftyOne.Pipeline.Engines.FlowElements;
+using FiftyOne.Pipeline.Engines.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+
+namespace FiftyOne.IpIntelligence.CloudTests;
+
+/// <summary>
+/// Unit tests for <see cref="IpiCloudEngine"/> processing, driven by a stub
+/// <see cref="ICloudRequestEngine"/> so no live cloud request is made.
+/// </summary>
+[TestClass]
+public class IpiCloudEngineProcessTests
+{
+    /// <summary>
+    /// A failed cloud request leaves the JsonResponse null. The engine must
+    /// not throw (the failure is already reported by the CloudRequestEngine),
+    /// in particular not the misleading PipelineConfigurationException
+    /// diagnosing the pipeline ordering, and its element data must still be
+    /// present in the flow data so downstream elements can run.
+    /// </summary>
+    [TestMethod]
+    public void Process_NullJsonResponse_DoesNotThrow()
+    {
+        using var pipeline = BuildPipeline(null);
+        using var data = pipeline.CreateFlowData();
+
+        data.Process();
+
+        AssertProcessedGracefully(data);
+    }
+
+    /// <summary>
+    /// Same as the null case for an empty JsonResponse.
+    /// </summary>
+    [TestMethod]
+    public void Process_EmptyJsonResponse_DoesNotThrow()
+    {
+        using var pipeline = BuildPipeline(string.Empty);
+        using var data = pipeline.CreateFlowData();
+
+        data.Process();
+
+        AssertProcessedGracefully(data);
+    }
+
+    private static void AssertProcessedGracefully(IFlowData data)
+    {
+        if (data.Errors != null)
+        {
+            foreach (var error in data.Errors)
+            {
+                Assert.IsFalse(
+                    error.ShouldThrow,
+                    $"No throwing error should be recorded when the cloud " +
+                    $"request failed, but found: {error.ExceptionData}");
+            }
+        }
+        Assert.IsTrue(
+            data.TryGetValue(
+                new TypedKey<IElementData>("ip"), out _),
+            "The ip element data should be added even when the cloud " +
+            "request failed.");
+    }
+
+    /// <summary>
+    /// A populated response is deserialized into the aspect data as before.
+    /// </summary>
+    [TestMethod]
+    public void Process_PopulatedJsonResponse_PopulatesProperties()
+    {
+        var json = @"{
+            ""ip"": {
+                ""asnname"": ""Example Networks""
+            }
+        }";
+        using var pipeline = BuildPipeline(json);
+        using var data = pipeline.CreateFlowData();
+
+        data.Process();
+
+        var ipData = data.Get<IIpIntelligenceData>();
+        Assert.IsNotNull(ipData);
+        Assert.IsTrue(ipData.AsnName.HasValue);
+        Assert.AreEqual("Example Networks", ipData.AsnName.Value);
+    }
+
+    /// <summary>
+    /// Build a pipeline containing a stub cloud request engine returning the
+    /// given JSON response followed by the engine under test. Process
+    /// exceptions are suppressed, matching how consumers configure cloud
+    /// pipelines, so the tests can inspect the recorded errors instead.
+    /// </summary>
+    private static IPipeline BuildPipeline(string json)
+    {
+        return new PipelineBuilder(new LoggerFactory())
+            .AddFlowElement(new StubRequestEngine(json, IpPublicProperties()))
+            .AddFlowElement(NewEngine())
+            .SetSuppressProcessExceptions(true)
+            .Build();
+    }
+
+    /// <summary>
+    /// The metadata the cloud advertises for the "ip" section.
+    /// </summary>
+    private static IReadOnlyDictionary<string, ProductMetaData>
+        IpPublicProperties()
+    {
+        var properties = new List<PropertyMetaData>
+        {
+            new PropertyMetaData { Name = "AsnName", Type = "String" },
+        };
+        return new Dictionary<string, ProductMetaData>
+        {
+            { "ip", new ProductMetaData { Properties = properties } },
+        };
+    }
+
+    private static IpiCloudEngine NewEngine()
+    {
+        return new IpiCloudEngine(
+            new TestLoggerFactory().CreateLogger<IpiCloudEngine>(),
+            CreateIpData);
+    }
+
+    private static IpDataCloud CreateIpData(
+        IPipeline pipeline,
+        FlowElementBase<IpDataCloud, IAspectPropertyMetaData> engine)
+    {
+        return new IpDataCloud(
+            new TestLoggerFactory().CreateLogger<IpDataCloud>(),
+            pipeline,
+            (IAspectEngine)engine,
+            MissingPropertyServiceCloud.Instance);
+    }
+
+    /// <summary>
+    /// Minimal cloud request engine that advertises a fixed set of properties
+    /// and returns a fixed JSON response, so the engine under test can be
+    /// driven without contacting the cloud.
+    /// </summary>
+    private class StubRequestEngine
+        : AspectEngineBase<CloudRequestData, IAspectPropertyMetaData>,
+            ICloudRequestEngine
+    {
+        private readonly string _json;
+
+        public StubRequestEngine(
+            string json,
+            IReadOnlyDictionary<string, ProductMetaData> publicProperties)
+            : base(new LoggerFactory().CreateLogger<StubRequestEngine>(), CreateData)
+        {
+            _json = json;
+            PublicProperties = publicProperties;
+        }
+
+        private static CloudRequestData CreateData(
+            IPipeline pipeline,
+            FlowElementBase<CloudRequestData, IAspectPropertyMetaData> element) =>
+            new CloudRequestData(null, pipeline, element as IAspectEngine);
+
+        public IReadOnlyDictionary<string, ProductMetaData> PublicProperties
+        { get; }
+
+        public override string DataSourceTier => "";
+        public override string ElementDataKey => "cloud";
+        public override IEvidenceKeyFilter EvidenceKeyFilter =>
+            new EvidenceKeyFilterWhitelist(new List<string>());
+        public override IList<IAspectPropertyMetaData> Properties =>
+            new List<IAspectPropertyMetaData>();
+
+        protected override void ProcessEngine(
+            IFlowData data, CloudRequestData aspectData) =>
+            aspectData.JsonResponse = _json;
+
+        protected override void UnmanagedResourcesCleanup() { }
+    }
+}

--- a/Tests/FiftyOne.IpIntelligence.Translation.Tests/TranslationTests.cs
+++ b/Tests/FiftyOne.IpIntelligence.Translation.Tests/TranslationTests.cs
@@ -24,6 +24,7 @@ using FiftyOne.IpIntelligence.Translation.Data;
 using FiftyOne.IpIntelligence.Translation.FlowElements;
 using FiftyOne.Pipeline.Core.Data;
 using FiftyOne.Pipeline.Core.FlowElements;
+using FiftyOne.Pipeline.Engines;
 using FiftyOne.Pipeline.Engines.Data;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -391,6 +392,67 @@ namespace FiftyOne.IpIntelligence.Translation.Tests
                         StringComparison.CurrentCulture) <= 0,
                     $"Expected '{namesAll[i - 1]}' <= '{namesAll[i]}'");
             }
+        }
+
+        /// <summary>
+        /// When the resource key does not grant the country code properties,
+        /// or the cloud request failed, reading them from the IP data throws
+        /// PropertyMissingException. The engine must treat that the same as
+        /// no value: no exception escapes and the "All" lists still contain
+        /// every known country.
+        /// </summary>
+        [TestMethod]
+        public void AllListsWhenIpPropertyAccessThrowsPropertyMissing()
+        {
+            var ipData = new Mock<IIpIntelligenceData>();
+            ipData.Setup(i => i["CountryCodesGeographical"])
+                .Returns(null);
+            ipData.Setup(i => i["CountryCodesPopulation"])
+                .Returns(null);
+            ipData.Setup(i => i.CountryCodesGeographical)
+                .Throws(new PropertyMissingException(
+                    "Property 'CountryCodesGeographical' not found in data " +
+                    "for element 'ip'."));
+            ipData.Setup(i => i.CountryCodesPopulation)
+                .Throws(new PropertyMissingException(
+                    "Property 'CountryCodesPopulation' not found in data " +
+                    "for element 'ip'."));
+
+            var element = new Mock<IFlowElement>();
+            element.SetupGet(i => i.Properties)
+                .Returns(new List<IElementPropertyMetaData>());
+            element.SetupGet(i => i.ElementDataKey).Returns("ip");
+            element.Setup(i => i.Process(It.IsAny<IFlowData>()))
+                .Callback<IFlowData>(data =>
+                {
+                    data.GetOrAdd(element.Object.ElementDataKey, p => ipData.Object);
+                });
+
+            var codeTranslationElement =
+                new CountryCodeTranslationEngineBuilder(_loggerFactory)
+                .Build();
+            var nameTranslationElement =
+                new CountriesTranslationEngineBuilder(_loggerFactory)
+                .Build();
+            using var pipeline = new PipelineBuilder(_loggerFactory)
+                .AddFlowElement(element.Object)
+                .AddFlowElement(codeTranslationElement)
+                .AddFlowElement(nameTranslationElement)
+                .Build();
+
+            using var flowData = pipeline.CreateFlowData();
+            flowData.AddEvidence("header.Accept-Language", "de_DE");
+            flowData.Process();
+
+            var result = flowData.Get<ICountriesTranslationData>();
+
+            Assert.IsTrue(
+                result.CountryNamesGeographicalAllTranslated.HasValue);
+            Assert.IsTrue(result.CountryCodesGeographicalAll.HasValue);
+            Assert.IsTrue(
+                result.CountryNamesGeographicalAllTranslated.Value.Count > 200);
+            Assert.IsTrue(
+                result.CountryCodesGeographicalAll.Value.Count > 200);
         }
 
         /// <summary>


### PR DESCRIPTION
Contributes to 51Degrees/Website#901 and 51Degrees/Website#900 (exception noise investigated under 51Degrees/Website#885).

### The problem

IpiCloudEngine overrode ProcessEngine and threw PipelineConfigurationException whenever the cloud response JSON was null or empty, which is the state every failed cloud request leaves behind. The message blamed pipeline ordering ("there is not a 'CloudRequestEngine' before the 'IpiCloudEngine'"), misdiagnosing outages as configuration faults, 15,442 occurrences in 30 days on the 51degrees.com website whose ordering is correct in all three of its IPI pipelines. Separately, CountriesTranslationEngine caught KeyNotFoundException and PipelineException around its reads of ip.CountryCodesGeographical and ip.CountryCodesPopulation but not PropertyMissingException, which extends plain Exception and is exactly what cloud aspect data throws when the property is unavailable (428 occurrences in the same window). When a catch did fire, the code then dereferenced the null result, and its typed reads of its own translated properties could fail with InvalidCastException on a string no-value placeholder.

### The fix

IpiCloudEngine now overrides ProcessCloudEngine instead of ProcessEngine. These are two rungs of the base class template. ProcessEngine is the outer step that owns getting the JSON, reporting a genuinely missing CloudRequestEngine with an accurate message, and handling the empty response case by logging once, calling MarkCloudRequestFailed so missing-property reasons say the cloud request failed rather than blaming the resource key, and recording a non-throwing flow error. ProcessCloudEngine is the designated subclass hook that the base only calls with non-empty JSON. Overriding the outer rung had replaced all of that orchestration with a pre-graceful-path copy, and opted the engine out of base class improvements (device detection picked up the graceful path, IPI did not). The engine now contains only the IPI-specific work of deserializing the ip section, matching its sibling CloudCountriesTranslationEngine.

CountriesTranslationEngine adds PropertyMissingException to the caught types, treats a null read result as no value, and reads its own weighted translated properties through a new GetWeightedOrEmpty helper. The helper looks the property up via AsDictionary().TryGetValue and pattern-matches the value to the weighted list type, returning an empty list when the property is absent, holds a differently typed no-value placeholder, or has no value. Empty is the correct degradation because the All-list builder merges the weighted values with the full embedded country dictionary, so with no weights it still produces the complete alphabetical list (the ContactUs country dropdown keeps working during outages, only visitor-specific weighting is lost). Because the helper tolerates both the current string placeholder and the typed placeholder coming in 51Degrees/pipeline-dotnet#350, this change has no release-ordering dependency on that PR.

### Testing

New stub-driven IpiCloudEngineProcessTests cover null, empty, and populated JSON responses without contacting the cloud, asserting no throw and that the ip element data is still added on failure. A new TranslationTests case drives the countries engine from ip data whose typed getters throw PropertyMissingException, asserting no escape and complete All lists. Cloud suite 32 passed, translation suite 15 passed, 0 failed.

### Rollout

Pages that previously logged an exception during outages now render with no IPI values and truthful missing-property reasons, matching device detection. Consumers that relied on catching PipelineConfigurationException to detect outages (none known) would move to FlowData.Errors. Follow-up once 51Degrees/pipeline-dotnet#350 ships as a package, declare the weighted list placeholder types for the country translations via the new AddTranslation generic overload.
