### PR TITLE
FIX: Select the client IP by validity, not presence

### DIFF
--- a/FiftyOne.IpIntelligence.Engine.OnPremise/ClientIpParser.cs
+++ b/FiftyOne.IpIntelligence.Engine.OnPremise/ClientIpParser.cs
@@ -51,13 +51,11 @@ namespace FiftyOne.IpIntelligence.Engine.OnPremise
         /// <param name="addressText">
         /// The canonical textual form of <paramref name="address"/>, for
         /// passing to services that take a string. Always canonical, never
-        /// the raw input: .NET accepts shapes the native engine's parser
-        /// rejects - an IPv6 zone index ("fe80::1%1"), inet_aton IPv4 forms
-        /// ("1.2.3", octal "012.1.2.3") - so forwarding the raw text would
-        /// reintroduce the native INCORRECT_IP_ADDRESS_FORMAT abort this
-        /// parser exists to prevent, and in the octal case would make the
-        /// forwarded value and the parsed address different addresses. A
-        /// zone index is stripped: it has no meaning to an IP lookup.
+        /// the raw input: .NET accepts an IPv6 zone index ("fe80::1%1")
+        /// which the native engine's parser rejects, so forwarding the raw
+        /// text would reintroduce the native INCORRECT_IP_ADDRESS_FORMAT
+        /// abort this parser exists to prevent. The zone index is stripped
+        /// rather than kept: it has no meaning to an IP lookup.
         /// </param>
         /// <returns>True when an address was read.</returns>
         public static bool TryParse(
@@ -95,7 +93,8 @@ namespace FiftyOne.IpIntelligence.Engine.OnPremise
 
             // A bare address. The text reported is the canonical form, not
             // the supplied text - see the addressText doc for why.
-            if (IPAddress.TryParse(candidate, out address))
+            if (IsDottedQuadOrIpV6(candidate) &&
+                IPAddress.TryParse(candidate, out address))
             {
                 address = StripZoneIndex(address);
                 addressText = address.ToString();
@@ -112,7 +111,8 @@ namespace FiftyOne.IpIntelligence.Engine.OnPremise
                 IsValidPort(candidate.Substring(portSeparatorIndex + 1)))
             {
                 var addressPart = candidate.Substring(0, portSeparatorIndex);
-                if (IPAddress.TryParse(addressPart, out address) &&
+                if (IsDottedQuadOrIpV6(addressPart) &&
+                    IPAddress.TryParse(addressPart, out address) &&
                     address.AddressFamily == AddressFamily.InterNetwork)
                 {
                     addressText = address.ToString();
@@ -175,6 +175,47 @@ namespace FiftyOne.IpIntelligence.Engine.OnPremise
                 address.ScopeId != 0
                 ? new IPAddress(address.GetAddressBytes())
                 : address;
+        }
+
+        /// <summary>
+        /// True when the text is a plain dotted-quad IPv4 address, or holds
+        /// a ':' and so can only be an IPv6 value. .NET additionally accepts
+        /// inet_aton IPv4 forms - a bare number ("3232235521" -> 192.168.0.1),
+        /// fewer than four parts ("1.2.3"), and octal octets ("012.1.2.3" ->
+        /// 10.1.2.3, which the native engine's atoi reads as 12.1.2.3). None
+        /// of those are a client IP: accepting them lets numeric junk count
+        /// as a valid address and outrank a real one, and resolves a
+        /// different address than the native lookup.
+        /// </summary>
+        private static bool IsDottedQuadOrIpV6(string text)
+        {
+            if (text.IndexOf(':') >= 0)
+            {
+                return true;
+            }
+
+            var octets = text.Split('.');
+            if (octets.Length != 4)
+            {
+                return false;
+            }
+
+            foreach (var octet in octets)
+            {
+                if (octet.Length == 0 || octet.Length > 3 ||
+                    (octet.Length > 1 && octet[0] == '0'))
+                {
+                    return false;
+                }
+                foreach (var character in octet)
+                {
+                    if (character < '0' || character > '9')
+                    {
+                        return false;
+                    }
+                }
+            }
+            return true;
         }
 
         private static bool IsValidPort(string portText)

--- a/FiftyOne.IpIntelligence.Engine.OnPremise/ClientIpParser.cs
+++ b/FiftyOne.IpIntelligence.Engine.OnPremise/ClientIpParser.cs
@@ -1,0 +1,192 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
+
+namespace FiftyOne.IpIntelligence.Engine.OnPremise
+{
+    /// <summary>
+    /// Parses the client IP address out of an evidence value.
+    /// <para>
+    /// Client IP evidence does not arrive in one shape. An edge may forward
+    /// it as a comma-separated list, and a connection-derived value routinely
+    /// carries a port (`82.132.237.238:34947`). Bare
+    /// <see cref="IPAddress.TryParse(string, out IPAddress)"/> rejects both,
+    /// so the same request could resolve elsewhere in the pipeline while this
+    /// engine saw no usable IP. This is the single tolerant parser used for
+    /// all client IP evidence.
+    /// </para>
+    /// </summary>
+    internal static class ClientIpParser
+    {
+        /// <summary>
+        /// Reads an IP address from a raw client-ip evidence value.
+        /// </summary>
+        /// <param name="rawValue">
+        /// The evidence value. May be null, may carry a port, and may be a
+        /// comma-separated forwarded list of which the first entry is used.
+        /// </param>
+        /// <param name="address">The address read from the value.</param>
+        /// <param name="addressText">
+        /// The canonical textual form of <paramref name="address"/>, for
+        /// passing to services that take a string. Always canonical, never
+        /// the raw input: .NET accepts shapes the native engine's parser
+        /// rejects - an IPv6 zone index ("fe80::1%1"), inet_aton IPv4 forms
+        /// ("1.2.3", octal "012.1.2.3") - so forwarding the raw text would
+        /// reintroduce the native INCORRECT_IP_ADDRESS_FORMAT abort this
+        /// parser exists to prevent, and in the octal case would make the
+        /// forwarded value and the parsed address different addresses. A
+        /// zone index is stripped: it has no meaning to an IP lookup.
+        /// </param>
+        /// <returns>True when an address was read.</returns>
+        public static bool TryParse(
+            string rawValue,
+            out IPAddress address,
+            out string addressText)
+        {
+            address = null;
+            addressText = null;
+            if (string.IsNullOrEmpty(rawValue))
+            {
+                return false;
+            }
+
+            // An edge may forward a chain; the first entry is the client.
+            var listSeparatorIndex = rawValue.IndexOf(',');
+            var candidate = listSeparatorIndex < 0
+                ? rawValue.Trim()
+                : rawValue.Substring(0, listSeparatorIndex).Trim();
+            if (candidate.Length == 0)
+            {
+                return false;
+            }
+
+            // Brackets are excluded from the fast path below deliberately.
+            // On some runtimes IPAddress.TryParse accepts the bracketed IPv6
+            // form and silently discards any port on it, so "[2001:db8::1]:443"
+            // would parse as an address while the text stayed bracketed and
+            // ported. Anything bracketed is handled explicitly and reported
+            // in canonical form.
+            if (candidate[0] == '[')
+            {
+                return TryParseBracketed(candidate, out address, out addressText);
+            }
+
+            // A bare address. The text reported is the canonical form, not
+            // the supplied text - see the addressText doc for why.
+            if (IPAddress.TryParse(candidate, out address))
+            {
+                address = StripZoneIndex(address);
+                addressText = address.ToString();
+                return true;
+            }
+
+            // Falls here when an IPv4 address carries a port, which
+            // IPAddress.TryParse rejects. An unbracketed IPv6 address keeps
+            // its colons: without brackets a trailing ":443" is
+            // indistinguishable from part of the address, so no port
+            // splitting is attempted for IPv6.
+            var portSeparatorIndex = candidate.LastIndexOf(':');
+            if (portSeparatorIndex > 0 &&
+                IsValidPort(candidate.Substring(portSeparatorIndex + 1)))
+            {
+                var addressPart = candidate.Substring(0, portSeparatorIndex);
+                if (IPAddress.TryParse(addressPart, out address) &&
+                    address.AddressFamily == AddressFamily.InterNetwork)
+                {
+                    addressText = address.ToString();
+                    return true;
+                }
+            }
+
+            address = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Parses "[address]" or "[address]:port" where the bracketed
+        /// address is IPv6.
+        /// </summary>
+        private static bool TryParseBracketed(
+            string candidate,
+            out IPAddress address,
+            out string addressText)
+        {
+            address = null;
+            addressText = null;
+
+            var closingBracketIndex = candidate.IndexOf(']');
+            if (closingBracketIndex < 2)
+            {
+                return false;
+            }
+
+            var afterBracket = candidate.Substring(closingBracketIndex + 1);
+            if (afterBracket.Length > 0 &&
+                (afterBracket[0] != ':' ||
+                IsValidPort(afterBracket.Substring(1)) == false))
+            {
+                return false;
+            }
+
+            var bracketedAddress = candidate.Substring(1, closingBracketIndex - 1);
+            if (IPAddress.TryParse(bracketedAddress, out address) &&
+                address.AddressFamily == AddressFamily.InterNetworkV6)
+            {
+                address = StripZoneIndex(address);
+                addressText = address.ToString();
+                return true;
+            }
+
+            address = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Returns the address without its IPv6 zone index ("fe80::1%1" ->
+        /// "fe80::1"). A zone index identifies the local interface the
+        /// address is reachable through; it has no meaning to an IP lookup,
+        /// and the native engine's parser rejects the '%' character.
+        /// </summary>
+        private static IPAddress StripZoneIndex(IPAddress address)
+        {
+            return address.AddressFamily == AddressFamily.InterNetworkV6 &&
+                address.ScopeId != 0
+                ? new IPAddress(address.GetAddressBytes())
+                : address;
+        }
+
+        private static bool IsValidPort(string portText)
+        {
+            // NumberStyles.None rejects signs and whitespace, so only a
+            // plain digit run within ushort range passes.
+            return portText.Length > 0 &&
+                ushort.TryParse(
+                    portText,
+                    NumberStyles.None,
+                    CultureInfo.InvariantCulture,
+                    out _);
+        }
+    }
+}

--- a/FiftyOne.IpIntelligence.Engine.OnPremise/FiftyOne.IpIntelligence.Engine.OnPremise.xml
+++ b/FiftyOne.IpIntelligence.Engine.OnPremise/FiftyOne.IpIntelligence.Engine.OnPremise.xml
@@ -4,6 +4,56 @@
         <name>FiftyOne.IpIntelligence.Engine.OnPremise</name>
     </assembly>
     <members>
+        <member name="T:FiftyOne.IpIntelligence.Engine.OnPremise.ClientIpParser">
+            <summary>
+            Parses the client IP address out of an evidence value.
+            <para>
+            Client IP evidence does not arrive in one shape. An edge may forward
+            it as a comma-separated list, and a connection-derived value routinely
+            carries a port (`82.132.237.238:34947`). Bare
+            <see cref="M:System.Net.IPAddress.TryParse(System.String,System.Net.IPAddress@)"/> rejects both,
+            so the same request could resolve elsewhere in the pipeline while this
+            engine saw no usable IP. This is the single tolerant parser used for
+            all client IP evidence.
+            </para>
+            </summary>
+        </member>
+        <member name="M:FiftyOne.IpIntelligence.Engine.OnPremise.ClientIpParser.TryParse(System.String,System.Net.IPAddress@,System.String@)">
+            <summary>
+            Reads an IP address from a raw client-ip evidence value.
+            </summary>
+            <param name="rawValue">
+            The evidence value. May be null, may carry a port, and may be a
+            comma-separated forwarded list of which the first entry is used.
+            </param>
+            <param name="address">The address read from the value.</param>
+            <param name="addressText">
+            The canonical textual form of <paramref name="address"/>, for
+            passing to services that take a string. Always canonical, never
+            the raw input: .NET accepts shapes the native engine's parser
+            rejects - an IPv6 zone index ("fe80::1%1"), inet_aton IPv4 forms
+            ("1.2.3", octal "012.1.2.3") - so forwarding the raw text would
+            reintroduce the native INCORRECT_IP_ADDRESS_FORMAT abort this
+            parser exists to prevent, and in the octal case would make the
+            forwarded value and the parsed address different addresses. A
+            zone index is stripped: it has no meaning to an IP lookup.
+            </param>
+            <returns>True when an address was read.</returns>
+        </member>
+        <member name="M:FiftyOne.IpIntelligence.Engine.OnPremise.ClientIpParser.TryParseBracketed(System.String,System.Net.IPAddress@,System.String@)">
+            <summary>
+            Parses "[address]" or "[address]:port" where the bracketed
+            address is IPv6.
+            </summary>
+        </member>
+        <member name="M:FiftyOne.IpIntelligence.Engine.OnPremise.ClientIpParser.StripZoneIndex(System.Net.IPAddress)">
+            <summary>
+            Returns the address without its IPv6 zone index ("fe80::1%1" ->
+            "fe80::1"). A zone index identifies the local interface the
+            address is reachable through; it has no meaning to an IP lookup,
+            and the native engine's parser rejects the '%' character.
+            </summary>
+        </member>
         <member name="T:FiftyOne.IpIntelligence.Engine.OnPremise.Data.ComponentMetaData">
             <summary>
             Data class that contains meta-data relating to a specific 

--- a/FiftyOne.IpIntelligence.Engine.OnPremise/FiftyOne.IpIntelligence.Engine.OnPremise.xml
+++ b/FiftyOne.IpIntelligence.Engine.OnPremise/FiftyOne.IpIntelligence.Engine.OnPremise.xml
@@ -30,13 +30,11 @@
             <param name="addressText">
             The canonical textual form of <paramref name="address"/>, for
             passing to services that take a string. Always canonical, never
-            the raw input: .NET accepts shapes the native engine's parser
-            rejects - an IPv6 zone index ("fe80::1%1"), inet_aton IPv4 forms
-            ("1.2.3", octal "012.1.2.3") - so forwarding the raw text would
-            reintroduce the native INCORRECT_IP_ADDRESS_FORMAT abort this
-            parser exists to prevent, and in the octal case would make the
-            forwarded value and the parsed address different addresses. A
-            zone index is stripped: it has no meaning to an IP lookup.
+            the raw input: .NET accepts an IPv6 zone index ("fe80::1%1")
+            which the native engine's parser rejects, so forwarding the raw
+            text would reintroduce the native INCORRECT_IP_ADDRESS_FORMAT
+            abort this parser exists to prevent. The zone index is stripped
+            rather than kept: it has no meaning to an IP lookup.
             </param>
             <returns>True when an address was read.</returns>
         </member>
@@ -52,6 +50,18 @@
             "fe80::1"). A zone index identifies the local interface the
             address is reachable through; it has no meaning to an IP lookup,
             and the native engine's parser rejects the '%' character.
+            </summary>
+        </member>
+        <member name="M:FiftyOne.IpIntelligence.Engine.OnPremise.ClientIpParser.IsDottedQuadOrIpV6(System.String)">
+            <summary>
+            True when the text is a plain dotted-quad IPv4 address, or holds
+            a ':' and so can only be an IPv6 value. .NET additionally accepts
+            inet_aton IPv4 forms - a bare number ("3232235521" -> 192.168.0.1),
+            fewer than four parts ("1.2.3"), and octal octets ("012.1.2.3" ->
+            10.1.2.3, which the native engine's atoi reads as 12.1.2.3). None
+            of those are a client IP: accepting them lets numeric junk count
+            as a valid address and outrank a real one, and resolves a
+            different address than the native lookup.
             </summary>
         </member>
         <member name="T:FiftyOne.IpIntelligence.Engine.OnPremise.Data.ComponentMetaData">

--- a/FiftyOne.IpIntelligence.Engine.OnPremise/FlowElements/IpiOnPremiseEngine.cs
+++ b/FiftyOne.IpIntelligence.Engine.OnPremise/FlowElements/IpiOnPremiseEngine.cs
@@ -277,16 +277,17 @@ namespace FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements
                         // parse, which ends its processing before
                         // lower-priority evidence prefixes are tried. Parse
                         // here instead: a value the tolerant parser can read
-                        // is passed on (ported, listed and bracketed forms
-                        // in a bare-address form; already-bare values
-                        // unchanged), and a value it cannot read is treated
-                        // as "this source yielded nothing" so the native
-                        // fall-through still happens. Dropping such a value
-                        // cannot lose usable evidence: every key this filter
-                        // admits comes from the data file's IP headers, and
-                        // the native engine parses every value it consumes
-                        // as an IP address, so a value that does not parse
-                        // could never have contributed a result.
+                        // is passed on in canonical bare-address form, and a
+                        // value it cannot read is treated as "this source
+                        // yielded nothing" so the native
+                        // fall-through still happens. This is deliberately
+                        // stricter than the native parser, which stops at a
+                        // '/' or ' ' and so resolved "1.2.3.4/24" and
+                        // "1.2.3.4 x" as 1.2.3.4; those now yield no result.
+                        // Requiring a whole, valid address is what lets a
+                        // malformed high-priority value fall through to a
+                        // valid lower-priority one, which is the point of
+                        // the change.
                         if (ClientIpParser.TryParse(
                             evidenceItem.Value?.ToString(),
                             out _,

--- a/FiftyOne.IpIntelligence.Engine.OnPremise/FlowElements/IpiOnPremiseEngine.cs
+++ b/FiftyOne.IpIntelligence.Engine.OnPremise/FlowElements/IpiOnPremiseEngine.cs
@@ -272,53 +272,78 @@ namespace FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements
                 {
                     if (EvidenceKeyFilter.Include(evidenceItem.Key))
                     {
-                        relevantEvidence.Add(new KeyValuePair<string, string>(
-                            evidenceItem.Key,
-                            evidenceItem.Value.ToString()));
+                        // The native engine raises
+                        // INCORRECT_IP_ADDRESS_FORMAT on a value it cannot
+                        // parse, which ends its processing before
+                        // lower-priority evidence prefixes are tried. Parse
+                        // here instead: a value the tolerant parser can read
+                        // is passed on (ported, listed and bracketed forms
+                        // in a bare-address form; already-bare values
+                        // unchanged), and a value it cannot read is treated
+                        // as "this source yielded nothing" so the native
+                        // fall-through still happens. Dropping such a value
+                        // cannot lose usable evidence: every key this filter
+                        // admits comes from the data file's IP headers, and
+                        // the native engine parses every value it consumes
+                        // as an IP address, so a value that does not parse
+                        // could never have contributed a result.
+                        if (ClientIpParser.TryParse(
+                            evidenceItem.Value?.ToString(),
+                            out _,
+                            out var addressText))
+                        {
+                            relevantEvidence.Add(new KeyValuePair<string, string>(
+                                evidenceItem.Key,
+                                addressText));
+                        }
                     }
                 }
                 (ipData as IpDataOnPremise).SetResults(_engine.process(relevantEvidence));
             }
 
-            // Capture the IP used for the lookup so we can echo it back as
-            // synthetic Ip / IpV6 properties. Priority mirrors the cloud's
-            // existing NetworkElement (query.client-ip > server.client-ip
-            // > anything else parseable from filtered evidence).
+            // Capture the client IP of the request so we can echo it back
+            // as synthetic Ip / IpV6 properties. Priority is
+            // query.client-ip > server.client-ip > anything else parseable
+            // from filtered evidence, but selection is by validity, not
+            // presence: a value that fails to parse lets the search
+            // continue to the next source instead of ending it.
             System.Net.IPAddress echoV4 = null;
             System.Net.IPAddress echoV6 = null;
 
-            string chosenIp = null;
-            if (data.TryGetEvidence("query.client-ip", out string queryIp))
+            System.Net.IPAddress chosenAddress = null;
+
+            bool TryUseEvidence(string evidenceKey)
             {
-                chosenIp = queryIp;
+                return data.TryGetEvidence(evidenceKey, out object rawValue) &&
+                    ClientIpParser.TryParse(
+                        rawValue?.ToString(), out chosenAddress, out _);
             }
-            else if (data.TryGetEvidence("server.client-ip", out string serverIp))
-            {
-                chosenIp = serverIp;
-            }
-            else
+
+            if (TryUseEvidence("query.client-ip") == false &&
+                TryUseEvidence("server.client-ip") == false)
             {
                 foreach (var evidenceItem in data.GetEvidence().AsDictionary())
                 {
                     if (EvidenceKeyFilter.Include(evidenceItem.Key) &&
-                        evidenceItem.Value is string candidate &&
-                        System.Net.IPAddress.TryParse(candidate, out _))
+                        ClientIpParser.TryParse(
+                            evidenceItem.Value?.ToString(),
+                            out chosenAddress,
+                            out _))
                     {
-                        chosenIp = candidate;
                         break;
                     }
                 }
             }
 
-            if (chosenIp != null && System.Net.IPAddress.TryParse(chosenIp, out var parsed))
+            if (chosenAddress != null)
             {
-                if (parsed.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork)
+                if (chosenAddress.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork)
                 {
-                    echoV4 = parsed;
+                    echoV4 = chosenAddress;
                 }
-                else if (parsed.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6)
+                else if (chosenAddress.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6)
                 {
-                    echoV6 = parsed;
+                    echoV6 = chosenAddress;
                 }
             }
 

--- a/Tests/FiftyOne.IpIntelligence.OnPremise.Tests/ClientIpParserTests.cs
+++ b/Tests/FiftyOne.IpIntelligence.OnPremise.Tests/ClientIpParserTests.cs
@@ -41,14 +41,16 @@ namespace FiftyOne.IpIntelligence.OnPremise.Tests
         [DataRow("1.2.3.4", "1.2.3.4", "1.2.3.4")]
         [DataRow("2001:db8::1", "2001:db8::1", "2001:db8::1")]
         [DataRow("2001:DB8::1", "2001:db8::1", "2001:db8::1")]
-        // Shapes .NET accepts but the native engine's parser rejects - the
-        // canonical text is what keeps them usable: an IPv6 zone index is
-        // stripped (it has no meaning to a lookup), and inet_aton IPv4
-        // forms (partial, octal) are expanded to the dotted quad .NET read
-        // them as, so the forwarded value and the parsed address agree.
+        // A shape .NET accepts but the native engine's parser rejects: the
+        // canonical text is what keeps it usable. The zone index is
+        // stripped, as it has no meaning to a lookup.
         [DataRow("fe80::1%1", "fe80::1", "fe80::1")]
-        [DataRow("1.2.3", "1.2.0.3", "1.2.0.3")]
-        [DataRow("012.1.2.3", "10.1.2.3", "10.1.2.3")]
+        // IPv4-mapped IPv6 stays in v6 form, so a v4 client arriving this
+        // way echoes as IpV6 with Ip NoValue, and is looked up in v6 form.
+        // Pinned so the choice is deliberate; unmapping it would be a
+        // parser change, not a test change.
+        [DataRow("::ffff:8.8.8.8", "::ffff:8.8.8.8", "::ffff:8.8.8.8")]
+        [DataRow("[::ffff:8.8.8.8]:443", "::ffff:8.8.8.8", "::ffff:8.8.8.8")]
         // IPv4 with a port.
         [DataRow("82.132.237.238:34947", "82.132.237.238", "82.132.237.238")]
         [DataRow("1.2.3.4:0", "1.2.3.4", "1.2.3.4")]
@@ -82,6 +84,14 @@ namespace FiftyOne.IpIntelligence.OnPremise.Tests
         [DataRow("not-an-ip")]
         // Out-of-range octet - the value from the original report.
         [DataRow("82.12.343.23")]
+        // inet_aton shapes .NET would parse but which are not client IPs:
+        // a bare number, fewer than four parts, and an octal octet the
+        // native engine would read as decimal.
+        [DataRow("12345")]
+        [DataRow("3232235521")]
+        [DataRow("1.2.3")]
+        [DataRow("012.1.2.3")]
+        [DataRow("12345:80")]
         // Port out of range, signed, or empty.
         [DataRow("1.2.3.4:65536")]
         [DataRow("1.2.3.4:-1")]

--- a/Tests/FiftyOne.IpIntelligence.OnPremise.Tests/ClientIpParserTests.cs
+++ b/Tests/FiftyOne.IpIntelligence.OnPremise.Tests/ClientIpParserTests.cs
@@ -1,0 +1,126 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using FiftyOne.IpIntelligence.Engine.OnPremise;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Net;
+
+namespace FiftyOne.IpIntelligence.OnPremise.Tests
+{
+    /// <summary>
+    /// Unit tests for <see cref="ClientIpParser"/>. These need no data file
+    /// and no native engine.
+    /// </summary>
+    [TestClass]
+    [TestCategory("IpIntelligence")]
+    [TestCategory("OnPremise")]
+    [TestCategory("IpEcho")]
+    public class ClientIpParserTests
+    {
+        [DataTestMethod]
+        // Bare addresses - the text comes back in canonical form.
+        [DataRow("1.2.3.4", "1.2.3.4", "1.2.3.4")]
+        [DataRow("2001:db8::1", "2001:db8::1", "2001:db8::1")]
+        [DataRow("2001:DB8::1", "2001:db8::1", "2001:db8::1")]
+        // Shapes .NET accepts but the native engine's parser rejects - the
+        // canonical text is what keeps them usable: an IPv6 zone index is
+        // stripped (it has no meaning to a lookup), and inet_aton IPv4
+        // forms (partial, octal) are expanded to the dotted quad .NET read
+        // them as, so the forwarded value and the parsed address agree.
+        [DataRow("fe80::1%1", "fe80::1", "fe80::1")]
+        [DataRow("1.2.3", "1.2.0.3", "1.2.0.3")]
+        [DataRow("012.1.2.3", "10.1.2.3", "10.1.2.3")]
+        // IPv4 with a port.
+        [DataRow("82.132.237.238:34947", "82.132.237.238", "82.132.237.238")]
+        [DataRow("1.2.3.4:0", "1.2.3.4", "1.2.3.4")]
+        [DataRow("1.2.3.4:65535", "1.2.3.4", "1.2.3.4")]
+        // Bracketed IPv6, with and without a port.
+        [DataRow("[2001:db8::1]:443", "2001:db8::1", "2001:db8::1")]
+        [DataRow("[2001:db8::1]", "2001:db8::1", "2001:db8::1")]
+        // Forwarded list - first entry, trimmed.
+        [DataRow("1.2.3.4, 5.6.7.8", "1.2.3.4", "1.2.3.4")]
+        [DataRow(" 2001:db8::1 , 5.6.7.8", "2001:db8::1", "2001:db8::1")]
+        [DataRow("82.132.237.238:34947, 10.0.0.1", "82.132.237.238", "82.132.237.238")]
+        // Surrounding whitespace.
+        [DataRow(" 1.2.3.4 ", "1.2.3.4", "1.2.3.4")]
+        public void TryParse_ValidValue_ReturnsAddress(
+            string rawValue,
+            string expectedAddress,
+            string expectedText)
+        {
+            var parsed = ClientIpParser.TryParse(
+                rawValue, out var address, out var addressText);
+
+            Assert.IsTrue(parsed, $"'{rawValue}' should parse.");
+            Assert.AreEqual(IPAddress.Parse(expectedAddress), address);
+            Assert.AreEqual(expectedText, addressText);
+        }
+
+        [DataTestMethod]
+        [DataRow(null)]
+        [DataRow("")]
+        [DataRow("   ")]
+        [DataRow("not-an-ip")]
+        // Out-of-range octet - the value from the original report.
+        [DataRow("82.12.343.23")]
+        // Port out of range, signed, or empty.
+        [DataRow("1.2.3.4:65536")]
+        [DataRow("1.2.3.4:-1")]
+        [DataRow("1.2.3.4:")]
+        [DataRow("1.2.3.4:port")]
+        // An unbracketed IPv6 address never has a port split off it, so a
+        // trailing port-like group makes the whole value unparseable rather
+        // than silently reinterpreting the address.
+        [DataRow("2001:db8::1:notaport")]
+        // Bracket forms that are not "[ipv6]" or "[ipv6]:port".
+        [DataRow("[1.2.3.4]:80")]
+        [DataRow("[2001:db8::1")]
+        [DataRow("[]")]
+        [DataRow("[2001:db8::1]443")]
+        [DataRow("[2001:db8::1]:")]
+        // A list whose first entry is empty is not rescued by later entries;
+        // the first entry is the client, and it is missing.
+        [DataRow(", 1.2.3.4")]
+        public void TryParse_InvalidValue_ReturnsFalseAndNulls(string rawValue)
+        {
+            var parsed = ClientIpParser.TryParse(
+                rawValue, out var address, out var addressText);
+
+            Assert.IsFalse(parsed, $"'{rawValue}' should not parse.");
+            Assert.IsNull(address);
+            Assert.IsNull(addressText);
+        }
+
+        [TestMethod]
+        public void TryParse_UnbracketedIpV6_KeepsItsColons()
+        {
+            // "2001:db8::1:443" is itself a valid IPv6 address; the parser
+            // must not strip a "port" from an unbracketed IPv6 value.
+            var parsed = ClientIpParser.TryParse(
+                "2001:db8::1:443", out var address, out var addressText);
+
+            Assert.IsTrue(parsed);
+            Assert.AreEqual(IPAddress.Parse("2001:db8::1:443"), address);
+            Assert.AreEqual("2001:db8::1:443", addressText);
+        }
+    }
+}

--- a/Tests/FiftyOne.IpIntelligence.OnPremise.Tests/FlowElements/ClientIpSelectionOnPremiseTests.cs
+++ b/Tests/FiftyOne.IpIntelligence.OnPremise.Tests/FlowElements/ClientIpSelectionOnPremiseTests.cs
@@ -1,0 +1,204 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using FiftyOne.Pipeline.Engines;
+using FiftyOne.Pipeline.Engines.Data;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Net;
+
+namespace FiftyOne.IpIntelligence.OnPremise.Tests.FlowElements
+{
+    /// <summary>
+    /// Tests for https://github.com/51Degrees/ip-intelligence-dotnet/issues/319
+    /// - the client IP echoed as the synthetic Ip / IpV6 properties must be
+    /// selected by validity, not presence, and the parser must accept the
+    /// shapes that arrive in production (a value carrying a port, a
+    /// comma-separated forwarded list).
+    /// </summary>
+    [TestClass]
+    [TestCategory("IpIntelligence")]
+    [TestCategory("OnPremise")]
+    [TestCategory("IpEcho")]
+    public class ClientIpSelectionOnPremiseTests : TestsBase
+    {
+        [TestInitialize]
+        public new void Init()
+        {
+            base.Init();
+            TestInitialize(PerformanceProfiles.LowMemory);
+        }
+
+        [TestMethod]
+        public void Process_InvalidQueryClientIp_FallsBackToServerClientIp()
+        {
+            using (var flowData = Wrapper.Pipeline.CreateFlowData())
+            {
+                // The value from the original report - an IPv4 shape with an
+                // out-of-range octet, so it fails to parse.
+                flowData.AddEvidence("query.client-ip", "82.12.343.23");
+                flowData.AddEvidence("server.client-ip", "1.2.3.4");
+                flowData.Process();
+
+                var data = flowData.Get<IIpIntelligenceData>();
+                Assert.IsTrue(data.Ip.HasValue,
+                    "A malformed query.client-ip must not suppress the echo " +
+                    "when a valid server.client-ip is on the same request.");
+                Assert.AreEqual(IPAddress.Parse("1.2.3.4"), data.Ip.Value);
+            }
+        }
+
+        [TestMethod]
+        public void Process_ValidQueryAndServerClientIp_QueryTakesPriority()
+        {
+            using (var flowData = Wrapper.Pipeline.CreateFlowData())
+            {
+                flowData.AddEvidence("query.client-ip", "5.6.7.8");
+                flowData.AddEvidence("server.client-ip", "1.2.3.4");
+                flowData.Process();
+
+                var data = flowData.Get<IIpIntelligenceData>();
+                Assert.IsTrue(data.Ip.HasValue,
+                    "Ip should have a value when valid evidence is supplied.");
+                Assert.AreEqual(IPAddress.Parse("5.6.7.8"), data.Ip.Value,
+                    "query.client-ip must keep priority over " +
+                    "server.client-ip when both are valid.");
+            }
+        }
+
+        [TestMethod]
+        public void Process_ClientIpWithPort_IsAccepted()
+        {
+            using (var flowData = Wrapper.Pipeline.CreateFlowData())
+            {
+                // The form a connection-derived value takes in production
+                // telemetry: address plus ephemeral port.
+                flowData.AddEvidence("server.client-ip", "82.132.237.238:34947");
+                flowData.Process();
+
+                var data = flowData.Get<IIpIntelligenceData>();
+                Assert.IsTrue(data.Ip.HasValue,
+                    "A client IP carrying a port must be accepted.");
+                Assert.AreEqual(IPAddress.Parse("82.132.237.238"), data.Ip.Value);
+            }
+        }
+
+        [TestMethod]
+        public void Process_ForwardedList_FirstEntryUsed()
+        {
+            using (var flowData = Wrapper.Pipeline.CreateFlowData())
+            {
+                flowData.AddEvidence("server.client-ip", "1.2.3.4, 5.6.7.8");
+                flowData.Process();
+
+                var data = flowData.Get<IIpIntelligenceData>();
+                Assert.IsTrue(data.Ip.HasValue,
+                    "A comma-separated forwarded list must be accepted.");
+                Assert.AreEqual(IPAddress.Parse("1.2.3.4"), data.Ip.Value,
+                    "The first entry of a forwarded list is the client.");
+            }
+        }
+
+        [TestMethod]
+        public void Process_BracketedIpV6WithPort_IsAccepted()
+        {
+            using (var flowData = Wrapper.Pipeline.CreateFlowData())
+            {
+                flowData.AddEvidence("server.client-ip", "[2001:db8::1]:443");
+                flowData.Process();
+
+                var data = flowData.Get<IIpIntelligenceData>();
+                Assert.IsTrue(data.IpV6.HasValue,
+                    "A bracketed IPv6 address carrying a port must be accepted.");
+                Assert.AreEqual(IPAddress.Parse("2001:db8::1"), data.IpV6.Value);
+                Assert.IsFalse(data.Ip.HasValue,
+                    "Ip should have no value for IPv6 evidence.");
+            }
+        }
+
+        [TestMethod]
+        public void Process_InvalidQueryClientIp_NativeLookupStillRuns()
+        {
+            // The synthetic Ip / IpV6 echo is computed entirely managed-side,
+            // so the other tests here cannot see whether the NATIVE lookup
+            // survived a malformed query.client-ip. Natively, an unparseable
+            // query-prefixed value raises INCORRECT_IP_ADDRESS_FORMAT and
+            // aborts before the server-prefixed evidence is tried; the
+            // evidence sanitization in ProcessEngine exists to prevent that.
+            // Process the same valid server IP with and without the
+            // malformed query value: the populated properties must match.
+            var controlKeys = GetPopulatedKeys(withInvalidQueryIp: false);
+            var affectedKeys = GetPopulatedKeys(withInvalidQueryIp: true);
+
+            Assert.IsTrue(controlKeys.Count > 1,
+                "The control run should populate properties beyond the " +
+                "echoed 'ip' - without that this test cannot detect an " +
+                "aborted native lookup.");
+            CollectionAssert.AreEquivalent(controlKeys, affectedKeys,
+                "A malformed query.client-ip must not change which " +
+                "properties the native lookup populates from the valid " +
+                "server.client-ip.");
+        }
+
+        private List<string> GetPopulatedKeys(bool withInvalidQueryIp)
+        {
+            using (var flowData = Wrapper.Pipeline.CreateFlowData())
+            {
+                if (withInvalidQueryIp)
+                {
+                    flowData.AddEvidence("query.client-ip", "82.12.343.23");
+                }
+                flowData.AddEvidence("server.client-ip", "8.8.8.8");
+                flowData.Process();
+
+                var populatedKeys = new List<string>();
+                foreach (var entry in
+                    flowData.Get<IIpIntelligenceData>().AsDictionary())
+                {
+                    var propertyValue = entry.Value as IAspectPropertyValue;
+                    if (propertyValue == null || propertyValue.HasValue)
+                    {
+                        populatedKeys.Add(entry.Key);
+                    }
+                }
+                return populatedKeys;
+            }
+        }
+
+        [TestMethod]
+        public void Process_EverySourceInvalid_BothNoValueAndNoThrow()
+        {
+            using (var flowData = Wrapper.Pipeline.CreateFlowData())
+            {
+                flowData.AddEvidence("query.client-ip", "82.12.343.23");
+                flowData.AddEvidence("server.client-ip", "not-an-ip");
+                flowData.Process();
+
+                var data = flowData.Get<IIpIntelligenceData>();
+                Assert.IsFalse(data.Ip.HasValue,
+                    "Ip should be NoValue when every source is invalid.");
+                Assert.IsFalse(data.IpV6.HasValue,
+                    "IpV6 should be NoValue when every source is invalid.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #319. IpiOnPremiseEngine picked the echoed client IP by presence, so a malformed query.client-ip suppressed Ip/IpV6 despite a valid server.client-ip, and the same value aborted the native lookup before its server-prefix fall-through (INCORRECT_IP_ADDRESS_FORMAT). Adds an internal ClientIpParser whose rules are derived from the address-parsing behaviour of the native engine in ip-intelligence-cxx: a strict dotted-quad IPv4 or an IPv6 value, an optional port, the first entry of a forwarded list, bracketed IPv6, and an IPv6 zone index stripped; inet_aton forms (bare numbers, partial quads, octal octets) are rejected. Selection validates during the search so an invalid value falls through to the next source, and evidence passed to the native engine is sanitized: parseable values in canonical form, unparseable values dropped so the native fall-through still happens. Declared behaviour changes: (1) values with an out-of-range octet such as 82.12.343.23 previously returned results keyed on the natively-clamped 82.12.255.23 and now yield NoValue; (2) values the native parser truncated at '/' or ' ' such as 1.2.3.4/24 or '1.2.3.4 x' previously resolved as 1.2.3.4 and now yield NoValue. New tests fail on the unfixed engine, including one proving the native lookup itself was affected; full on-premise suite green.