### PR TITLE
FIX: Report supplied-but-invalid IP evidence in the echo

### DIFF
--- a/FiftyOne.IpIntelligence.Engine.OnPremise/Data/IpDataOnPremise.cs
+++ b/FiftyOne.IpIntelligence.Engine.OnPremise/Data/IpDataOnPremise.cs
@@ -81,15 +81,41 @@ namespace FiftyOne.IpIntelligence.Engine.OnPremise.Data
         private readonly Lazy<IReadOnlyDictionary<string, object>> _asDict;
 
         /// <summary>
+        /// The reason reported for both echo properties when the request did
+        /// carry a client IP but none of the supplied values could be read as
+        /// an address.
+        /// </summary>
+        internal const string InvalidIpEvidenceMessage =
+            "The IP supplied as evidence was not valid.";
+
+        /// <summary>
         /// Set the echo IP values captured from request evidence.
         /// Called by IpiOnPremiseEngine.ProcessEngine.
         /// </summary>
         /// <param name="ipv4">Parsed IPv4 address, or null if none.</param>
         /// <param name="ipv6">Parsed IPv6 address, or null if none.</param>
-        internal void SetEchoIp(System.Net.IPAddress ipv4, System.Net.IPAddress ipv6)
+        /// <param name="clientIpSupplied">
+        /// True when the request carried a non-blank client IP value,
+        /// whatever its content. It separates the two reasons an echo
+        /// property can have no value: nothing was supplied, or what was
+        /// supplied could not be read as an IP address. Reporting the second
+        /// as the first sends the caller looking for a header that is in fact
+        /// present - see issue #332.
+        /// </param>
+        internal void SetEchoIp(
+            System.Net.IPAddress ipv4,
+            System.Net.IPAddress ipv6,
+            bool clientIpSupplied)
         {
             _echoIp = new FiftyOne.Pipeline.Engines.Data.AspectPropertyValue<System.Net.IPAddress>();
             _echoIpV6 = new FiftyOne.Pipeline.Engines.Data.AspectPropertyValue<System.Net.IPAddress>();
+
+            // Only when NEITHER family resolved does supplied evidence mean
+            // the supplied evidence was bad. If one family resolved, the
+            // other is genuinely absent from the request rather than
+            // invalid, and "was not valid" would misreport it.
+            var suppliedButInvalid =
+                clientIpSupplied && ipv4 == null && ipv6 == null;
 
             if (ipv4 != null)
             {
@@ -97,7 +123,9 @@ namespace FiftyOne.IpIntelligence.Engine.OnPremise.Data
             }
             else
             {
-                _echoIp.NoValueMessage = "IPv4 was not supplied as evidence.";
+                _echoIp.NoValueMessage = suppliedButInvalid
+                    ? InvalidIpEvidenceMessage
+                    : "IPv4 was not supplied as evidence.";
             }
 
             if (ipv6 != null)
@@ -106,7 +134,9 @@ namespace FiftyOne.IpIntelligence.Engine.OnPremise.Data
             }
             else
             {
-                _echoIpV6.NoValueMessage = "IPv6 was not supplied as evidence.";
+                _echoIpV6.NoValueMessage = suppliedButInvalid
+                    ? InvalidIpEvidenceMessage
+                    : "IPv6 was not supplied as evidence.";
             }
         }
 

--- a/FiftyOne.IpIntelligence.Engine.OnPremise/FiftyOne.IpIntelligence.Engine.OnPremise.xml
+++ b/FiftyOne.IpIntelligence.Engine.OnPremise/FiftyOne.IpIntelligence.Engine.OnPremise.xml
@@ -296,13 +296,28 @@
             property does not exist.
             </param>
         </member>
-        <member name="M:FiftyOne.IpIntelligence.Engine.OnPremise.Data.IpDataOnPremise.SetEchoIp(System.Net.IPAddress,System.Net.IPAddress)">
+        <member name="F:FiftyOne.IpIntelligence.Engine.OnPremise.Data.IpDataOnPremise.InvalidIpEvidenceMessage">
+            <summary>
+            The reason reported for both echo properties when the request did
+            carry a client IP but none of the supplied values could be read as
+            an address.
+            </summary>
+        </member>
+        <member name="M:FiftyOne.IpIntelligence.Engine.OnPremise.Data.IpDataOnPremise.SetEchoIp(System.Net.IPAddress,System.Net.IPAddress,System.Boolean)">
             <summary>
             Set the echo IP values captured from request evidence.
             Called by IpiOnPremiseEngine.ProcessEngine.
             </summary>
             <param name="ipv4">Parsed IPv4 address, or null if none.</param>
             <param name="ipv6">Parsed IPv6 address, or null if none.</param>
+            <param name="clientIpSupplied">
+            True when the request carried a non-blank client IP value,
+            whatever its content. It separates the two reasons an echo
+            property can have no value: nothing was supplied, or what was
+            supplied could not be read as an IP address. Reporting the second
+            as the first sends the caller looking for a header that is in fact
+            present - see issue #332.
+            </param>
         </member>
         <member name="M:FiftyOne.IpIntelligence.Engine.OnPremise.Data.IpDataOnPremise.AsDictionary">
             <summary>

--- a/FiftyOne.IpIntelligence.Engine.OnPremise/FlowElements/IpiOnPremiseEngine.cs
+++ b/FiftyOne.IpIntelligence.Engine.OnPremise/FlowElements/IpiOnPremiseEngine.cs
@@ -313,11 +313,35 @@ namespace FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements
 
             System.Net.IPAddress chosenAddress = null;
 
+            // Whether the request offered a client IP at all, tracked
+            // alongside the search so that "nothing resolved" can be told
+            // apart from "nothing was offered". Every key the filter admits
+            // is a client IP header - the whitelist is built from the data
+            // file's unique headers under the 'query.' and 'server.'
+            // prefixes - so a non-empty value none of these sources could
+            // parse means the IP supplied was invalid, which is reported
+            // differently. See SetEchoIp.
+            var clientIpSupplied = false;
+
+            void NoteSupplied(string rawText)
+            {
+                // A blank value is nothing offered rather than something
+                // unreadable, so it must not be reported as invalid.
+                if (string.IsNullOrWhiteSpace(rawText) == false)
+                {
+                    clientIpSupplied = true;
+                }
+            }
+
             bool TryUseEvidence(string evidenceKey)
             {
-                return data.TryGetEvidence(evidenceKey, out object rawValue) &&
-                    ClientIpParser.TryParse(
-                        rawValue?.ToString(), out chosenAddress, out _);
+                if (data.TryGetEvidence(evidenceKey, out object rawValue) == false)
+                {
+                    return false;
+                }
+                var rawText = rawValue?.ToString();
+                NoteSupplied(rawText);
+                return ClientIpParser.TryParse(rawText, out chosenAddress, out _);
             }
 
             if (TryUseEvidence("query.client-ip") == false &&
@@ -325,11 +349,13 @@ namespace FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements
             {
                 foreach (var evidenceItem in data.GetEvidence().AsDictionary())
                 {
-                    if (EvidenceKeyFilter.Include(evidenceItem.Key) &&
-                        ClientIpParser.TryParse(
-                            evidenceItem.Value?.ToString(),
-                            out chosenAddress,
-                            out _))
+                    if (EvidenceKeyFilter.Include(evidenceItem.Key) == false)
+                    {
+                        continue;
+                    }
+                    var rawText = evidenceItem.Value?.ToString();
+                    NoteSupplied(rawText);
+                    if (ClientIpParser.TryParse(rawText, out chosenAddress, out _))
                     {
                         break;
                     }
@@ -348,7 +374,8 @@ namespace FiftyOne.IpIntelligence.Engine.OnPremise.FlowElements
                 }
             }
 
-            (ipData as IpDataOnPremise).SetEchoIp(echoV4, echoV6);
+            (ipData as IpDataOnPremise).SetEchoIp(
+                echoV4, echoV6, clientIpSupplied);
         }
 
         /// <summary>

--- a/Tests/FiftyOne.IpIntelligence.OnPremise.Tests/FlowElements/ClientIpSelectionOnPremiseTests.cs
+++ b/Tests/FiftyOne.IpIntelligence.OnPremise.Tests/FlowElements/ClientIpSelectionOnPremiseTests.cs
@@ -20,6 +20,7 @@
  * such notice(s) shall fulfill the requirements of that article.
  * ********************************************************************* */
 
+using FiftyOne.IpIntelligence.Engine.OnPremise.Data;
 using FiftyOne.Pipeline.Engines;
 using FiftyOne.Pipeline.Engines.Data;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -198,6 +199,14 @@ namespace FiftyOne.IpIntelligence.OnPremise.Tests.FlowElements
                     "Ip should be NoValue when every source is invalid.");
                 Assert.IsFalse(data.IpV6.HasValue,
                     "IpV6 should be NoValue when every source is invalid.");
+
+                // Issue #332 - NoValue here is "supplied and rejected", not
+                // "never supplied".
+                Assert.AreEqual(
+                    IpDataOnPremise.InvalidIpEvidenceMessage,
+                    data.Ip.NoValueMessage,
+                    "Exhausting every source must report the supplied IP " +
+                    "as invalid, not as absent.");
             }
         }
     }

--- a/Tests/FiftyOne.IpIntelligence.OnPremise.Tests/FlowElements/IpEchoOnPremiseCoreTests.cs
+++ b/Tests/FiftyOne.IpIntelligence.OnPremise.Tests/FlowElements/IpEchoOnPremiseCoreTests.cs
@@ -26,6 +26,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
 using System.Net;
 using FiftyOne.IpIntelligence;
+using FiftyOne.IpIntelligence.Engine.OnPremise.Data;
 
 namespace FiftyOne.IpIntelligence.OnPremise.Tests.FlowElements
 {
@@ -133,6 +134,135 @@ namespace FiftyOne.IpIntelligence.OnPremise.Tests.FlowElements
                     "AsDictionary must NOT contain 'ip' when no IP evidence is supplied.");
                 Assert.IsFalse(dict.ContainsKey("ipv6"),
                     "AsDictionary must NOT contain 'ipv6' when no IP evidence is supplied.");
+            }
+        }
+
+        /// <summary>
+        /// https://github.com/51Degrees/ip-intelligence-dotnet/issues/332
+        /// - the reported repro. An IP was supplied and rejected, so saying
+        /// it was never supplied sends the caller looking for a header that
+        /// is in fact present.
+        /// </summary>
+        [TestMethod]
+        public void Process_UnparseableIpEvidence_ReportsInvalidNotMissing()
+        {
+            using (var flowData = Wrapper.Pipeline.CreateFlowData())
+            {
+                flowData.AddEvidence("server.client-ip", "not-an-ip");
+                flowData.Process();
+
+                var data = flowData.Get<IIpIntelligenceData>();
+                Assert.IsFalse(data.Ip.HasValue,
+                    "Ip should be NoValue for an unparseable client IP.");
+                Assert.IsFalse(data.IpV6.HasValue,
+                    "IpV6 should be NoValue for an unparseable client IP.");
+
+                Assert.AreEqual(
+                    IpDataOnPremise.InvalidIpEvidenceMessage,
+                    data.Ip.NoValueMessage,
+                    "Ip must report the supplied IP as invalid, not absent.");
+                Assert.AreEqual(
+                    IpDataOnPremise.InvalidIpEvidenceMessage,
+                    data.IpV6.NoValueMessage,
+                    "IpV6 must report the supplied IP as invalid, not absent.");
+            }
+        }
+
+        [TestMethod]
+        public void Process_EveryIpSourceUnparseable_ReportsInvalidNotMissing()
+        {
+            using (var flowData = Wrapper.Pipeline.CreateFlowData())
+            {
+                flowData.AddEvidence("query.client-ip", "82.12.343.23");
+                flowData.AddEvidence("server.client-ip", "not-an-ip");
+                flowData.Process();
+
+                var data = flowData.Get<IIpIntelligenceData>();
+                Assert.AreEqual(
+                    IpDataOnPremise.InvalidIpEvidenceMessage,
+                    data.Ip.NoValueMessage,
+                    "Exhausting every source without a parse is still " +
+                    "evidence supplied and rejected.");
+            }
+        }
+
+        [TestMethod]
+        public void Process_NoIpEvidence_ReportsNotSupplied()
+        {
+            using (var flowData = Wrapper.Pipeline.CreateFlowData())
+            {
+                // intentionally no IP evidence
+                flowData.Process();
+
+                var data = flowData.Get<IIpIntelligenceData>();
+                Assert.AreNotEqual(
+                    IpDataOnPremise.InvalidIpEvidenceMessage,
+                    data.Ip.NoValueMessage,
+                    "An absent client IP must not be reported as invalid.");
+                Assert.IsTrue(
+                    data.Ip.NoValueMessage.Contains("not supplied as evidence"),
+                    $"Unexpected Ip NoValueMessage: '{data.Ip.NoValueMessage}'");
+                Assert.IsTrue(
+                    data.IpV6.NoValueMessage.Contains("not supplied as evidence"),
+                    $"Unexpected IpV6 NoValueMessage: '{data.IpV6.NoValueMessage}'");
+            }
+        }
+
+        [TestMethod]
+        public void Process_BlankIpEvidence_ReportsNotSupplied()
+        {
+            using (var flowData = Wrapper.Pipeline.CreateFlowData())
+            {
+                // A blank header is nothing offered, not something
+                // unreadable, so it keeps the "not supplied" wording.
+                flowData.AddEvidence("server.client-ip", "   ");
+                flowData.Process();
+
+                var data = flowData.Get<IIpIntelligenceData>();
+                Assert.IsTrue(
+                    data.Ip.NoValueMessage.Contains("not supplied as evidence"),
+                    $"Unexpected Ip NoValueMessage: '{data.Ip.NoValueMessage}'");
+            }
+        }
+
+        [TestMethod]
+        public void Process_ValidIPv4Evidence_IpV6ReportsNotSupplied()
+        {
+            using (var flowData = Wrapper.Pipeline.CreateFlowData())
+            {
+                // The address parsed, so the family that did not resolve is
+                // absent from the request rather than invalid. Reporting it
+                // as invalid would be the same misreport in the opposite
+                // direction.
+                flowData.AddEvidence("server.client-ip", "1.2.3.4");
+                flowData.Process();
+
+                var data = flowData.Get<IIpIntelligenceData>();
+                Assert.IsTrue(data.Ip.HasValue);
+                Assert.AreEqual(
+                    "IPv6 was not supplied as evidence.",
+                    data.IpV6.NoValueMessage,
+                    "A valid IPv4 must leave IpV6 reported as not supplied.");
+            }
+        }
+
+        [TestMethod]
+        public void Process_InvalidThenValidIpEvidence_IpV6ReportsNotSupplied()
+        {
+            using (var flowData = Wrapper.Pipeline.CreateFlowData())
+            {
+                flowData.AddEvidence("query.client-ip", "82.12.343.23");
+                flowData.AddEvidence("server.client-ip", "1.2.3.4");
+                flowData.Process();
+
+                var data = flowData.Get<IIpIntelligenceData>();
+                Assert.IsTrue(data.Ip.HasValue);
+                Assert.AreEqual(
+                    "IPv6 was not supplied as evidence.",
+                    data.IpV6.NoValueMessage,
+                    "A rejected value elsewhere on the request must not " +
+                    "make the unresolved family read as invalid once " +
+                    "another source resolved.");
             }
         }
     }


### PR DESCRIPTION
Fixes #332. The echo reported 'IPv4/IPv6 was not supplied as evidence' whenever no address resolved, including when a client IP was supplied and rejected - sending callers looking for a header that is in fact present. This is fallout from #319: the stricter ClientIpParser added in #323 turned a class of inputs from resolved-by-clamping into no value, and every one of them landed on the wrong message. ProcessEngine now tracks whether the request offered a non-blank client IP and passes that to SetEchoIp, which reports 'The IP supplied as evidence was not valid' when neither family resolved. A blank value counts as not supplied. The wording only changes when NEITHER family resolved - if one did, the other is genuinely absent rather than invalid, and the old wording stays correct. Adds 6 tests. Verified with -p:Platform=x64: 110 passed, 0 failed, 13 pre-existing skips. A negative control forcing the pre-fix decision fails exactly the 3 message assertions and no others, confirming the tests catch the bug rather than passing vacuously.